### PR TITLE
Added a PersonalId class to generate Id #s for US, UK & Canada

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -148,6 +148,7 @@ require 'faker/company'
 require 'faker/internet'
 require 'faker/lorem'
 require 'faker/name'
+require_relative 'faker/personal_id'
 require 'faker/phone_number'
 require 'faker/version'
 

--- a/lib/faker/personal_id.rb
+++ b/lib/faker/personal_id.rb
@@ -1,0 +1,17 @@
+module Faker
+  class PersonalId < Base
+    class << self
+      def ssn
+        "%03i-00-%04i" % [ Random.rand(999), Random.rand(9999)]
+      end
+
+      def nino
+        "QQ%06i%s" % [ Random.rand(999999), (65 + rand(4)).chr ]
+      end
+
+      def sin
+         "0%02i-%03i-%03i" % [ Random.rand(99), Random.rand(999), Random.rand(999)]
+      end
+    end
+  end
+end

--- a/test/test_faker_personal_id.rb
+++ b/test/test_faker_personal_id.rb
@@ -1,0 +1,21 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerPersonalId < Test::Unit::TestCase
+
+  def setup
+    @tester = Faker::PersonalId
+  end
+
+  def test_ssn #Social Security Number; United States - allows 987-65-4320 - 987-65-4329 for advertising thus is safe for fake data
+    assert @tester.ssn.match(/\d\d\d-00-\d\d\d\d/) #987-65-432
+  end
+
+  def test_nino #National Insurance number; UK Based on this: http://www.hmrc.gov.uk/manuals/nimmanual/NIM39110.htm QQ should be a valid range
+    assert @tester.nino.match(/QQ\d\d\d\d\d\d[A-D]/)
+  end
+
+  def test_sin #Social Insurance Number; Canada; zero (0) is reserved as a leading digit for sample numbers
+    assert @tester.sin.match(/0\d\d-\d\d\d-\d\d\d/)
+  end
+
+end


### PR DESCRIPTION
Added a PersonalId Class that creates a Correctly formatted but bogus Social Security Number, National Insurance Number or Social Insurance Number for the US, UK or Canada respectively. They are designed not to accidentally create a real number.
