### PR TITLE
Avoid generating email/domain_word with non-ascii

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -78,8 +78,8 @@ module Faker
 
       # Helper for the common approach of grabbing a translation
       # with an array of values and selecting one of them.
-      def fetch(key)
-        fetched = translate("faker.#{key}")
+      def fetch(key, opt = {})
+        fetched = translate("faker.#{key}", opt)
         fetched = fetched.sample if fetched.respond_to?(:sample)
         if fetched.match(/^\//) and fetched.match(/\/$/) # A regex
           regexify(fetched)

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -7,6 +7,10 @@ module Faker
         parse('company.name')
       end
 
+      def english_name
+        parse('company.english_name')
+      end
+
       def suffix
         fetch('company.suffix')
       end

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -37,11 +37,10 @@ module Faker
         end
 
         fix_umlauts([
-          Proc.new { Name.first_name.gsub(/\W/, '').downcase },
+          Proc.new { downcase_ascii_user_first_name },
           Proc.new {
-            [ Name.first_name, Name.last_name ].map {|n|
-              n.gsub(/\W/, '')
-            }.join(separators.sample).downcase }
+            [ downcase_ascii_user_first_name, downcase_ascii_user_last_name ].join(separators.sample).downcase
+          }
         ].sample.call)
       end
 
@@ -69,7 +68,14 @@ module Faker
       end
 
       def domain_word
-        Company.name.split(' ').first.gsub(/\W/, '').downcase
+        name = Company.name
+        word = name.split(' ').first.gsub(/\W/, '').downcase
+
+        unless word == ''
+          word
+        else
+          Company.english_name.split(' ').first.gsub(/\W/, '').downcase
+        end
       end
 
       def domain_suffix
@@ -103,6 +109,28 @@ module Faker
       def slug(words = nil, glue = nil)
         glue ||= %w[- _ .].sample
         (words || Faker::Lorem::words(2).join(' ')).gsub(' ', glue).downcase
+      end
+
+      private
+
+      def downcase_ascii_user_first_name
+        downcase_name = Name.first_name.gsub(/\W/, '').downcase
+
+        unless downcase_name == ''
+          downcase_name
+        else
+          Name.english_first_name.gsub(/\W/, '').downcase
+        end
+      end
+
+      def downcase_ascii_user_last_name
+        downcase_name = Name.last_name.gsub(/\W/, '').downcase
+
+        unless downcase_name == ''
+          downcase_name
+        else
+          Name.english_last_name.gsub(/\W/, '').downcase
+        end
       end
     end
   end

--- a/lib/faker/name.rb
+++ b/lib/faker/name.rb
@@ -13,6 +13,9 @@ module Faker
       def prefix;     fetch('name.prefix'); end
       def suffix;     fetch('name.suffix'); end
 
+      def english_first_name; fetch('name.first_name', locale: :en); end
+      def english_last_name;  fetch('name.first_name', locale: :en); end
+
       # Generate a buzzword-laden job title
       # Wordlist from http://www.bullshitjob.com/title/
       def title; fetch('name.title.descriptor') + ' ' + fetch('name.title.level') + ' ' + fetch('name.title.job'); end

--- a/lib/locales/ja.yml
+++ b/lib/locales/ja.yml
@@ -14,6 +14,11 @@ ja:
       street_name:
         - "#{Name.first_name}#{street_suffix}"
         - "#{Name.last_name}#{street_suffix}"
+    company:
+      english_name:
+        - "#{Name.english_last_name} #{suffix}"
+        - "#{Name.english_last_name}-#{Name.english_last_name}"
+        - "#{Name.english_last_name}, #{Name.english_last_name} and #{Name.english_last_name}"
     phone_number:
       formats: ['0####-#-####', '0###-##-####', '0##-###-####', '0#-####-####']
     cell_phone:

--- a/test/test_faker_internet_for_ja.rb
+++ b/test/test_faker_internet_for_ja.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerInternetForJa < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Internet
+    Faker::Config.locale = 'ja'
+  end
+
+  def teardown
+    Faker::Config.locale = nil
+  end
+
+  def test_email
+    assert @tester.email.match(/.+@.+\.\w+/)
+  end
+
+  def test_free_email
+    assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
+  end
+
+  def test_safe_email
+    assert @tester.safe_email.match(/.+@example.(com|net|org)/)
+  end
+
+  def test_user_name
+    assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
+  end
+end


### PR DESCRIPTION
In ja and other locales using non-ascii characters,
generating emails and domains from the faker name
results in non-ascii emails and domains.

Such email and domains are invalid, because they contain non-ascii
characters.

```
Faker::Config.locale = :ja
Faker::Internet.email #=> "@.biz"
```

So, if first_name and last_name is non-ascii characters,
we use fist_name and last_name in locale :en.