### PR TITLE
latitude and longitude should be float instead of string.

### DIFF
--- a/lib/faker/address.rb
+++ b/lib/faker/address.rb
@@ -47,11 +47,11 @@ module Faker
       def country_code;  fetch('address.country_code');  end
 
       def latitude
-        ((rand * 180) - 90).to_s
+        ((rand * 180) - 90).to_f
       end
 
       def longitude
-        ((rand * 360) - 180).to_s
+        ((rand * 360) - 180).to_f
       end
 
     end


### PR DESCRIPTION
Mongodb gives an exception when set coordinates as string. So they should be set as float. Globally coordinates should be set as float by default. 
