### PR TITLE
Add Gem Version badge to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-Faker
+Faker 
 =====
+
+<!-- Badges -->
+<a href="http://badge.fury.io/rb/faker"><img src="https://badge.fury.io/rb/faker@2x.png" alt="Gem Version" height="18"></a>
+
 This gem is a port of Perl's Data::Faker library that generates fake data.
 
 It comes in very handy for taking screenshots (taking screenshots for my


### PR DESCRIPTION
Add a helpful Gem Version badge to the README so that it is easier to see what the latest version of the library is in Rubygems.