### PR TITLE
Add Faker::Name.initials

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Faker::Lorem.words #=> ["dolores", "adipisci", "nesciunt"]
 Faker::Lorem.words(4) #=> ["culpa", "recusandae", "aut", "omnis"]
 Faker::Lorem.words(4, true) #=> ["colloco", "qui", "vergo", "deporto"]
 
+Faker::Lorem.character #=> "x"
+
 # Optional arguments: char_count=255
 Faker::Lorem.characters #=> "uw1ep04lhs0c4d931n1jmrspprf5wrj85fefue0y7y6m56b6omquh7br7dhqijwlawejpl765nb1716idmp3xnfo85v349pzy2o9rir23y2qhflwr71c1585fnynguiphkjm8p0vktwitcsm16lny7jzp9t4drwav3qmhz4yjq4k04x14gl6p148hulyqioo72tf8nwrxxcclfypz2lc58lsibgfe5w5p0xv95peafjjmm2frkhdc6duoky0aha"
 Faker::Lorem.characters(10) #=> "ang9cbhoa8"
@@ -241,6 +243,13 @@ Faker::Lorem.paragraphs #=> ""
 Faker::Lorem.paragraphs(1) #=> ""
 Faker::Lorem.paragraphs(1, true) #=> ""
 
+Faker::Lorem.letter #=> "x"
+
+# Optional arguments: char_count=255
+Faker::Lorem.letters #=>
+"ScWNDzuNadqCbcTospsMXGQcEdUxeGMFkrbKeUKrotzLBpuDYpgMJAQKNcJzxNHXDGcgSiDsjgWQTRGkGMKktTCfuHMhJnogQbWDJYqDAHxJnnKJHUjeeBryEYCAnxKzLUMPgthtcoQWBgtwzPvJJDMVqavaDytFJhZFDkCzDshqqwymwDMDRjNXwjkVGXmqbkDXyugFNdvcgnXKTkyBuBniDjKJwUbbxnhkxtujZVANPYmjZLLqXyqBJpNNErT"
+Faker::Lorem.letters(5) #=> "fSfyP"
+
 ```
 
 ###Faker::Name
@@ -259,6 +268,11 @@ Faker::Name.prefix #=> "Mr."
 Faker::Name.suffix #=> "IV"
 
 Faker::Name.title #=> "Legacy Creative Director"
+
+# Optional arguments: seperator=nil
+# If nil, we use a random seperator ('', '.', '. ')
+Faker::Name.initials #=> "D. D"
+Faker::Name.initials('.') #=> "M.G.P."
 
 ```
 

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -50,6 +50,17 @@ module Faker
         end
       end
 
+      def letter
+        letters(1)
+      end
+
+      def letters(char_count = 255)
+        return '' if char_count.respond_to?(:to_i) && char_count.to_i < 1
+        char_count = resolve(char_count)
+        letters = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+        (1..char_count).map { letters[rand(letters.length)] }.shuffle.join
+      end
+
     private
 
       # If an array or range is passed, a random value will be selected.

--- a/lib/faker/name.rb
+++ b/lib/faker/name.rb
@@ -13,6 +13,14 @@ module Faker
       def prefix;     fetch('name.prefix'); end
       def suffix;     fetch('name.suffix'); end
 
+      def initials sep=nil
+        getsep = -> { sep || ['', '.', '. '][rand(3)] }
+
+        Lorem.letters(rand(4) + 1)
+          .split('')
+          .reduce('') { |v, memo| "#{memo}#{getsep.call}#{v}" }
+      end
+
       # Generate a buzzword-laden job title
       # Wordlist from http://www.bullshitjob.com/title/
       def title; fetch('name.title.descriptor') + ' ' + fetch('name.title.level') + ' ' + fetch('name.title.job'); end

--- a/test/test_faker_lorem.rb
+++ b/test/test_faker_lorem.rb
@@ -84,4 +84,24 @@ class TestFakerLorem < Test::Unit::TestCase
     assert(250 <= range.length && range.length <= 500)
     assert(array.length == 250 || array.length == 500)
   end
+
+  def test_letter
+    assert @tester.letter.length == 1
+  end
+  
+  def test_letter_type
+    assert @tester.letter.class == String
+  end
+
+  def test_letters
+    assert @tester.letters.length == 255
+  end
+
+  def test_letters_with_args
+    1000.times do
+      l = @tester.letters 500
+      assert l.length == 500
+      assert l.match(/[^a-zA-Z]/).nil?
+    end
+  end
 end

--- a/test/test_faker_name.rb
+++ b/test/test_faker_name.rb
@@ -17,4 +17,9 @@ class TestFakerName < Test::Unit::TestCase
   def test_suffix
     assert @tester.suffix.match(/[A-Z][a-z]*\.?/)
   end
+
+  def test_initials
+    assert @tester.initials.match(/^([A-Za-z][. ]*){1,4}$/)
+    assert @tester.initials(';').match(/^([A-Za-z];){1,4}$/)
+  end
 end


### PR DESCRIPTION
A person's initials.

Also add `Faker::Lorem.letters`; this returns a list of letters (a-zA-z), we
already had `Faker::Lorem.characters` & `Faker::Number.number`, this was "required"
for Name.initials and it seemed natural to add this as well.

Also added `Faker::Lorem.character` to the README