### PR TITLE
Use only english domains for email

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -57,7 +57,7 @@ module Faker
       end
 
       def domain_name
-        [ fix_umlauts(domain_word), domain_suffix ].join('.')
+        [ domain_word, domain_suffix ].join('.')
       end
 
       def fix_umlauts(string)
@@ -72,7 +72,9 @@ module Faker
       end
 
       def domain_word
-        Company.name.split(' ').first.gsub(/\W/, '').downcase
+        I18n.with_locale(:en) do
+          Company.name.split(' ').first.gsub(/\W/, '').downcase
+        end
       end
 
       def domain_suffix

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -8,6 +8,9 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_email
     assert @tester.email.match(/.+@.+\.\w+/)
+    I18n.with_locale(:ru) do
+      assert @tester.email.match(/.+@.+\.\w+/)
+    end
   end
 
   def test_free_email


### PR DESCRIPTION
For non latin locales `Faker::Internet.email` did't work, cause `Faker::Company.name` has non latin letters and `gsub(/\W/, '')`.
```
[1] pry(main)> Faker::Config.locale = 'ru'
=> "ru"
[2] pry(main)> Faker::Internet.email
=> "keenan@.org"
[3] pry(main)> Faker::Company.name
=> "ОП ХабаровскПромСнаб"
```
So, I don't think it's important to change locale in this place.