### PR TITLE
Added support for norwegian cell phone numbers

### DIFF
--- a/lib/locales/nb-NO.yml
+++ b/lib/locales/nb-NO.yml
@@ -29,7 +29,7 @@ nb-NO:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"
         - "#{Name.last_name}, #{Name.last_name} og #{Name.last_name}"
-      
+
     internet:
       domain_suffix: ["no", "com", "net", "org"]
 
@@ -49,4 +49,7 @@ nb-NO:
         - "#{first_name} #{last_name}"
 
     phone_number:
+      formats: ["########", "## ## ## ##", "### ## ###", "+47 ## ## ## ##"]
+
+    cell_phone:
       formats: ["########", "## ## ## ##", "### ## ###", "+47 ## ## ## ##"]


### PR DESCRIPTION
Added some config to support the Faker::PhoneNumber.cell_phone for norwegian cell phone numbers. Didn't find any tests for this locale, so didn't add a test for this new property. I'd be down to write some tests for the "no-NB"-locale if neccesary, so please contact me if this is needed.