### PR TITLE
Added a format to Time between,backward and forward to return a string formatted for US users.

### DIFF
--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -12,30 +12,30 @@ module Faker
 
     class << self
       def between(from, to, period = :all, format = :utc)
-        if format == :us
-          time = super(from, to).to_time + random_time(period)
-          I18n.l( DateTime.parse(time.to_s) )
-        else
+        if format == :utc
           super(from, to).to_time + random_time(period)
+        else
+          time = super(from, to).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s), :format => format )
         end
 
       end
 
       def forward(days = 365, period = :all, format = :utc)
-        if format == :us
-          time = super(days).to_time + random_time(period)
-          I18n.l( DateTime.parse(time.to_s) )
-        else
+        if format == :utc
           super(days).to_time + random_time(period)
+        else
+          time = super(days).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s), :format => format )
         end
       end
 
       def backward(days = 365, period = :all, format = :utc)
-        if format == :us
-          time = super(days).to_time + random_time(period)
-          I18n.l( DateTime.parse(time.to_s) )
-        else
+        if format == :utc
           super(days).to_time + random_time(period)
+        else
+          time = super(days).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s), :format => format)
         end
       end
       private

--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -11,18 +11,33 @@ module Faker
     }
 
     class << self
-      def between(from, to, period = :all)
-        super(from, to).to_time + random_time(period)
+      def between(from, to, period = :all, format = :utc)
+        if format == :us
+          time = super(from, to).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s) )
+        else
+          super(from, to).to_time + random_time(period)
+        end
+
       end
 
-      def forward(days = 365, period = :all)
-        super(days).to_time + random_time(period)
+      def forward(days = 365, period = :all, format = :utc)
+        if format == :us
+          time = super(days).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s) )
+        else
+          super(days).to_time + random_time(period)
+        end
       end
 
-      def backward(days = 365, period = :all)
-        super(days).to_time + random_time(period)
+      def backward(days = 365, period = :all, format = :utc)
+        if format == :us
+          time = super(days).to_time + random_time(period)
+          I18n.l( DateTime.parse(time.to_s) )
+        else
+          super(days).to_time + random_time(period)
+        end
       end
-
       private
 
       def random_time(period)

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -153,3 +153,8 @@ en:
       author:
         - "#{Name.name}"
         - "#{Company.name}"
+  time:
+    formats:
+      default: "%m/%d/%Y %I:%M %p"
+    am: "AM"
+    pm: "PM"

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -155,6 +155,6 @@ en:
         - "#{Company.name}"
   time:
     formats:
-      default: "%m/%d/%Y %I:%M %p"
+      us: "%m/%d/%Y %I:%M %p"
     am: "AM"
     pm: "PM"

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -54,6 +54,26 @@ class TestFakerTime < Test::Unit::TestCase
     end
   end
 
+  def test_format
+    from = Date.today
+    to   = Date.today + 15
+    format = :us
+    100.times do
+      period = @time_ranges.keys.to_a.sample
+
+      random_backward  = @tester.backward(30,period, format)
+      random_between  = @tester.between(from,to,period, format)
+      random_forward  = @tester.forward(30,period, format)
+      [random_backward, random_between, random_forward].each do |result|
+          assert result.is_a?(String), "Expected a String, but got #{result.class}"
+          assert_nothing_thrown "Not a valid date string" do
+            date_format = "%m/%d/%Y %I:%M %p"
+            DateTime.strptime(result, date_format)
+          end
+      end
+    end
+  end
+
   def test_time_period
     from = Date.today
     to   = Date.today + 15

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -66,7 +66,7 @@ class TestFakerTime < Test::Unit::TestCase
       random_forward  = @tester.forward(30,period, format)
       [random_backward, random_between, random_forward].each do |result|
           assert result.is_a?(String), "Expected a String, but got #{result.class}"
-          assert_nothing_thrown "Not a valid date string" do
+          assert_nothing_raised "Not a valid date string" do
             date_format = "%m/%d/%Y %I:%M %p"
             DateTime.strptime(result, date_format)
           end


### PR DESCRIPTION
Added a format to Time between,backward and forward to return a string formatted for US users. This is useful when testing time pickers

Because some date pickers return dates in this format: "12/23/2014 10:30 AM". When testing controllers that can handle this format we have to pass that formatted string to patch create and post update. Something like :

```
start_date = Faker::Time.between(2.days.ago, Time.now, :all,:us)
end_date = Faker::Time.between(2.days.ago, Time.now, :all,:us)
post :create,{ job: attributes_for(:job, start_date: start_date, end_date: end_date)}
```

that is nicer than having to do

```
start_date = I18n.l(DateTime.parse(Faker::Time.between(2.days.ago, Time.now, :all).to_s )
...
```

I needed this when testing a controller with rspec that received a date from a form that used the gem bootstrap3-datetimepicker-rails 

this can be expanded to add more formats by adding them to the locales files
