### PR TITLE
Update pt-BR.yml

### DIFF
--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -24,7 +24,7 @@ pt-BR:
                  "Suécia", "Suíça", "Síria", "Taiwan", "Tajiquistão", "Tanzânia", "Tailândia", "Timor-Leste", "Togo", "Tokelau", "Tonga", "Trinidá e Tobago", "Tunísia", 
                  "Turquia", "Turcomenistão", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ucrânia", "Emirados Árabes Unidos", "Reino Unido", "Estados Unidos da América", 
                  "Estados Unidos das Ilhas Virgens", "Uruguai", "Uzbequistão", "Vanuatu", "Venezuela", "Vietnã", "Wallis and Futuna", "Sahara", "Yemen", "Zâmbia", "Zimbábue"]
-      building_number: ["#####", "####", "###"]
+      building_number: ["#####", "####", "###", "s/n"]
       street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
       secondary_address: ["Apto. ###", "Sobrado ##", "Casa #", "Lote ##", "Quadra ##"]
       # Though these are US-specific, they are here (in the default locale) for backwards compatibility
@@ -34,7 +34,7 @@ pt-BR:
       default_country: [Brasil]
 
     company:
-      suffix: ["S.A.", "LTDA", "e Associados", "Comércio"]
+      suffix: ["S.A.", "LTDA", "e Associados", "Comércio", "EIRELI"]
       name:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"


### PR DESCRIPTION
Minor additions:

- Added "s/n" for building number, which is pretty common to find addresses w/o numbers in Brazil.

- Added "EIRELI" for company suffix, which is for companies with individual responsibilities.