### PR TITLE
[TASK] Update the Ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
 script: bundle exec rake test


### PR DESCRIPTION
* drop Ruby 1.9.2 which had its end of life some time ago
* use "2.1" instead of "2.1.0" to allow Travis to use the latest point release
  as Ruby uses Semantic Versioning starting with version 2.1.0