### PR TITLE
Added range functionality to Faker::Commerce.price

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Faker::Commerce.product_name #=> "Practical Granite Shirt"
 
 Faker::Commerce.price #=> "44.6"
 
+# Send in an optional range for price
+Faker::Commerce.price(5,10) #=> "6.0"
+
 ```
 
 ###Faker::Company

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -23,7 +23,7 @@ module Faker
         fetch('commerce.product_name.adjective') + ' ' + fetch('commerce.product_name.material') + ' ' + fetch('commerce.product_name.product')
       end
 
-      def price(from = 0, to = 100)
+      def price(from = 0, to = 100.0)
         (Faker::Base::rand_in_range(from, to) * 100).floor/100.0
       end
 

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -23,10 +23,9 @@ module Faker
         fetch('commerce.product_name.adjective') + ' ' + fetch('commerce.product_name.material') + ' ' + fetch('commerce.product_name.product')
       end
 
-      def price
-        random = Random.new
-        (random.rand(0..100.0) * 100).floor/100.0
-      end    
+      def price(from=0, to=100)
+        (Faker::Base::rand_in_range(from, to) * 100).floor/100.0
+      end
 
       private
 

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -23,7 +23,7 @@ module Faker
         fetch('commerce.product_name.adjective') + ' ' + fetch('commerce.product_name.material') + ' ' + fetch('commerce.product_name.product')
       end
 
-      def price(from=0, to=100)
+      def price(from = 0, to = 100)
         (Faker::Base::rand_in_range(from, to) * 100).floor/100.0
       end
 

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -24,7 +24,7 @@ module Faker
       end
 
       def price(from = 0, to = 100.0)
-        (Faker::Base::rand_in_range(from, to) * 100).floor/100.0
+        (rand_in_range(from, to) * 100).floor/100.0
       end
 
       private

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -5,15 +5,15 @@ class TestFakerCommerce < Test::Unit::TestCase
   def setup
     @tester = Faker::Commerce
   end
-  
+
   def test_color
     assert @tester.color.match(/[a-z]+\.?/)
   end
-  
+
   def test_department
     assert @tester.department.match(/[A-Z][a-z]+\.?/)
   end
-  
+
   def test_single_department_should_not_contain_separators
     assert_match(/\A[A-Za-z]+\z/, @tester.department(1))
   end
@@ -59,11 +59,17 @@ class TestFakerCommerce < Test::Unit::TestCase
     assert @tester.product_name.match(/[A-Z][a-z]+\.?/)
   end
 
-  def test_price
+  def default_test_price
     assert_includes 0..100, @tester.price
   end
 
   def test_price_is_float
     assert @tester.price.is_a? Float
+  end
+
+  def test_with_custom_range
+    price = Faker::Commerce.price(45,95)
+    assert_includes 45..95, price
+    assert_not_equal 0, price
   end
 end


### PR DESCRIPTION
This pull request allows a range (via two values) to be passed to `Faker::Commerce.price` with the idea that developers who have price level validations can choose where this random price falls.  After digging through the code I realized there was already a helper method found in [`Faker::Base.rand_in_range`](https://github.com/stympy/faker/blob/master/lib/faker.rb#L152-L155) which does exactly that.  

Prior to this all prices fell between `0..100`.
