### PR TITLE
[Fix issue #300] Generate random Hex, RGB, HSL, or HSLA color value

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -159,6 +159,7 @@ end
 
 require 'faker/address'
 require 'faker/code'
+require 'faker/color'
 require 'faker/company'
 require 'faker/finance'
 require 'faker/internet'

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -19,12 +19,12 @@ module Faker
       end
 
       def single_hsl_color
-        @single_hsla_color = (0.00..360.00).to_a.sample.round(2)
+        @single_hsla_color = Faker::Base::rand_in_range(0.0, 360.00).round(2)
         @single_hsla_color
       end
 
       def alpha_channel
-        @alpha_channel = (0.00..1.00).to_a.sample.round(2)
+        @alpha_channel = rand
         @alpha_channel
       end
 

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -1,0 +1,10 @@
+module Faker
+  class Color < Base
+    class << self
+      def hex_color
+        color = "#%06x" % (rand * 0xffffff)
+      end
+    end
+
+  end
+end

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -7,6 +7,7 @@ module Faker
 
       def single_rgb_color
         @single_rgb_color = rand(0..255)
+        @single_rgb_color
       end
 
       def rgb_color
@@ -19,10 +20,12 @@ module Faker
 
       def single_hsl_color
         @single_hsla_color = rand(0.00..360.00).round(2)
+        @single_hsla_color
       end
 
       def alpha_channel
         @alpha_channel = rand(0.00..1.00).round(2)
+        @alpha_channel
       end
 
       def hsl_color

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -6,7 +6,7 @@ module Faker
       end
 
       def single_rgb_color
-        @single_rgb_color = rand(0..255)
+        @single_rgb_color = (0..255).to_a.sample
         @single_rgb_color
       end
 
@@ -19,12 +19,12 @@ module Faker
       end
 
       def single_hsl_color
-        @single_hsla_color = rand(0.00..360.00).round(2)
+        @single_hsla_color = (0.00..360.00).to_a.sample.round(2)
         @single_hsla_color
       end
 
       def alpha_channel
-        @alpha_channel = rand(0.00..1.00).round(2)
+        @alpha_channel = (0.00..1.00).to_a.sample.round(2)
         @alpha_channel
       end
 

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -16,6 +16,18 @@ module Faker
         end
         @rgb_colors
       end
+
+      def single_hsl_color
+        @single_hsla_color = rand(0.00..360.00).round(2)
+      end
+
+      def hsl_color
+        @hsl_colors = []
+        3.times do
+          @hsl_colors.push single_hsl_color
+        end
+        @hsl_colors
+      end
     end
   end
 end

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -2,9 +2,20 @@ module Faker
   class Color < Base
     class << self
       def hex_color
-        color = "#%06x" % (rand * 0xffffff)
+        @hex_color = "#%06x" % (rand * 0xffffff)
+      end
+
+      def single_rgb_color
+        @single_rgb_color = rand(0..255)
+      end
+
+      def rgb_color
+        @rgb_colors = []
+        3.times do
+          @rgb_colors.push single_rgb_color
+        end
+        @rgb_colors
       end
     end
-
   end
 end

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -21,12 +21,25 @@ module Faker
         @single_hsla_color = rand(0.00..360.00).round(2)
       end
 
+      def alpha_channel
+        @alpha_channel = rand(0.00..1.00).round(2)
+      end
+
       def hsl_color
         @hsl_colors = []
         3.times do
           @hsl_colors.push single_hsl_color
         end
         @hsl_colors
+      end
+
+      def hsla_color
+        @hsla_colors = []
+        3.times do
+          @hsla_colors.push single_hsl_color
+        end
+        @hsla_colors.push alpha_channel
+        @hsla_colors
       end
     end
   end

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -21,4 +21,17 @@ class TestFakerColor < Test::Unit::TestCase
       assert color.between?(0, 255)
     end
   end
+
+  def test_single_hsl_color
+    assert @tester.single_hsl_color.between?(0.0, 360.0)
+  end
+
+  def test_hsl_color
+    @result = @tester.hsl_color
+    assert @result.length == 3
+
+    @result.each do |color|
+      assert color.between?(0.0, 360.0)
+    end
+  end
 end

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -8,4 +8,17 @@ class TestFakerColor < Test::Unit::TestCase
   def test_hex_color
     assert @tester.hex_color.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
   end
+
+  def test_single_rgb_color
+    assert @tester.single_rgb_color.between?(0, 255)
+  end
+
+  def test_rgb_color
+    @result = @tester.rgb_color
+    assert @result.length == 3
+
+    @result.each do |color|
+      assert color.between?(0, 255)
+    end
+  end
 end

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -34,4 +34,13 @@ class TestFakerColor < Test::Unit::TestCase
       assert color.between?(0.0, 360.0)
     end
   end
+
+  def test_hsla_color
+    @result = @tester.hsla_color
+    assert @result.length == 4
+
+    @result.each do |color|
+      assert color.between?(0.0, 360.0) || color.between?(0.0, 1.0)
+    end
+  end
 end

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -1,0 +1,11 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerColor < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Color
+  end
+
+  def test_hex_color
+    assert @tester.hex_color.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
+  end
+end


### PR DESCRIPTION
[Fix issue #300] Generate random hex color value with test

The test checks for the following:

```
^		 #start of the line
#		 #  must constains a "#" symbols
(		 #  start of group #1
[A-Fa-f0-9]{6} #    any strings in the list, with length of 6
|		 #    ..or
[A-Fa-f0-9]{3} #    any strings in the list, with length of 3
)		 #  end of group #1 
$		 #end of the line
```

This adds support for generating:
* Single RGB Color value
* Array of RGB Color Values (Red, Green, Blue)
* Hex Color Value
* Single HSL Color Value
* Array of HSL Color Values (Hue, Saturation, Lightness)
* Array of HSLA Color Values (Hue, Saturation, Lightness, Alpha)