### PR TITLE
Faker::Number.digit even distribution

### DIFF
--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -12,7 +12,7 @@ module Faker
       end
 
       def digit
-        (rand() * 9).round.to_s
+        rand(10).to_s
       end
 
       def hexadecimal(digits)

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -28,6 +28,21 @@ class TestFakerNumber < Test::Unit::TestCase
     assert (1..1000).collect {|i| @tester.digit == "9"}.include?(true)
   end
 
+  def test_even_distribution
+    assert stats = {}
+    assert times = 10000
+
+    times.times do
+      assert num = @tester.digit
+      stats[num] ||= 0
+      assert stats[num] += 1
+    end
+
+    stats.each do |k, v|
+      assert_in_delta 10.0, 100.0 * v / times, 2.0
+    end
+  end
+
   def test_between
     100.times do
       random_number = @tester.between(-50, 50)


### PR DESCRIPTION
The existing code for creating the random digit in `Faker::Number` creates more '1'-'8's and relatively few '0's and '9's, [see this gist showing the distribution of the current code](https://gist.github.com/smathy/d4d2a1c1cc04b87572fa)

This patch fixes the issue and includes a test.