### PR TITLE
Remove insignificant zeros in Faker::Number

### DIFF
--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -2,13 +2,35 @@ module Faker
   class Number < Base
     class << self
       def number(digits)
+        num = ''
+        if digits > 1
+          num = non_zero_digit
+          digits -= 1
+        end
+        num + leading_zero_number(digits)
+      end
+
+      def leading_zero_number(digits)
         (1..digits).collect {digit}.join
+      end
+
+      def decimal_part digits
+        num = ''
+        if digits > 1
+          num = non_zero_digit
+          digits -= 1
+        end
+        leading_zero_number(digits) + num
       end
 
       def decimal(l_digits, r_digits = 2)
         l_d = self.number(l_digits)
-        r_d = self.number(r_digits)
+        r_d = self.decimal_part(r_digits)
         "#{l_d}.#{r_d}"
+      end
+
+      def non_zero_digit
+        ( rand(9) + 1 ).to_s
       end
 
       def digit

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+require 'minitest/mock'
 
 class TestFakerNumber < Test::Unit::TestCase
   def setup
@@ -73,5 +74,19 @@ class TestFakerNumber < Test::Unit::TestCase
   def test_hexadecimal
     assert @tester.hexadecimal(4).match(/[0-9a-f]{4}/)
     assert @tester.hexadecimal(7).match(/[0-9a-f]{7}/)
+  end
+
+  def test_insignificant_zero
+    Faker::Number.stub :digit, 0 do
+      assert_equal '0', @tester.number(1)
+      100.times do
+        assert_match /^[1-9]0/, @tester.number(2)
+      end
+
+      assert_equal '0.0', @tester.decimal(1,1)
+      100.times do
+        assert_match /^0\.0[1-9]/, @tester.decimal(1,2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Right now if you do `Faker::Number.number(5)` then you can get a string like `"01234"` which when turned into a number will end up as `1234` - ie. not a 5 digit number at all.  Likewise `Faker::Number.decimal(5)` can get a string like `"12345.60"` which will turn into `12345.6` which is also not generally what people will expect.

This PR fixes that for all argument values above 1, when the arg is 1 then I allow a single `"0"` to be returned, because I figure people who want a single digit will probably want the possibility of a zero.

Tests included too.