### PR TITLE
Use more realistic logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Faker::Company.ein #=> "34-8488813"
 
 Faker::Company.duns_number #=> "08-341-3736"
 
-# Get a random company logo url in GIF format.
-Faker::Company.logo #=> "http://www.biz-logo.com/examples/007.gif"
+# Get a random company logo url in PNG format.
+Faker::Company.logo #=> "http://pigment.github.com/fake-logos/logos/medium/color/5.png"
 
 ```
 

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -29,10 +29,10 @@ module Faker
         ('%09d' % rand(10 ** 9)).gsub(/(\d\d)(\d\d\d)(\d\d\d\d)/, '\\1-\\2-\\3')
       end
 
-      # Get a random company logo url in GIF format.
+      # Get a random company logo url in PNG format.
       def logo
-        rand_num = Random.rand(76) + 1
-        "http://www.biz-logo.com/examples/#{ rand_num < 10 ? "00" : "0" }#{rand_num}.gif"
+        rand_num = Random.rand(13) + 1
+        "http://pigment.github.io/fake-logos/logos/medium/color/#{rand_num}.png"
       end
     end
 

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -14,6 +14,6 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def test_logo
-	  assert @tester.logo.match(%r{http://www.biz-logo.com/examples/\d+\.gif})
+	  assert @tester.logo.match(%r{http://pigment.github.io/fake-logos/logos/medium/color/\d+\.png})
   end
 end


### PR DESCRIPTION
The logos from biz-logo.com are better than nothing, but they have a lot of padding/junk around them which makes them not very useful in a lot of cases.

**Example of biz-logo.com existing logo**

![](http://www.biz-logo.com/examples/046.gif)

**Example from pigment/fake-logos**

![](http://pigment.github.io/fake-logos/logos/small/color/5.png)

The logos at http://github.com/pigment/fake-logos have been released for this purpose. There are 13 convincing PNG and SVG logos for a range of business types. 