### PR TITLE
Add a Singpore NRIC generator

### DIFF
--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -19,6 +19,17 @@ module Faker
         value << "-#{vd}"
       end
 
+      # By default generates a Singaporean NRIC ID for someone
+      # who is born between the age of 18 and 65.
+      def nric(min_age = 18, max_age = 65)
+        birthyear = Date.birthday(min_age, max_age).year
+        prefix = birthyear < 2000 ? 'S' : 'T'
+        values = birthyear.to_s[-2..-1]
+        values << regexify(/\d{5}/)
+        check_alpha = generate_nric_check_alphabet(values, prefix)
+        "#{prefix}#{values}#{check_alpha}"
+      end
+
     private
 
       def generate_base10_isbn
@@ -57,6 +68,13 @@ module Faker
       def rut_verificator_digit(rut)
         total = rut.to_s.rjust(8, '0').split(//).zip(%w(3 2 7 6 5 4 3 2)).collect{|a, b| a.to_i * b.to_i}.inject(:+)
         (11 - total % 11).to_s.gsub(/10/, 'k').gsub(/11/, '0')
+      end
+
+      def generate_nric_check_alphabet(values, prefix)
+        weight = %w(2 7 6 5 4 3 2)
+        total = values.split(//).zip(weight).collect { |a, b| a.to_i * b.to_i }.inject(:+)
+        total = total + 4 if prefix == 'T'
+        %w(A B C D E F G H I Z J)[10 - total % 11]
       end
     end
   end

--- a/test/test_faker_code.rb
+++ b/test/test_faker_code.rb
@@ -24,4 +24,8 @@ class TestFakerCode < Test::Unit::TestCase
   def test_rut
     assert @tester.rut.match(/^\d{1,8}-(\d|k)$/)
   end
+
+  def test_nric
+    assert @tester.nric.match(/^(S|T)\d{7}[A-JZ]$/)
+  end
 end


### PR DESCRIPTION
![lol](http://i0.wp.com/sethlui.com/wp-content/uploads/2014/05/gum1.jpg?zoom=2&resize=1024%2C768)

In Singapore, we use nric numbers that looks like this to identify citizens:

    T0207917D

It would be great if Faker can generate this. :smile: 
Though I am not sure if this is the right way to do this. Many countries have their own way of identifying citizens (see http://en.wikipedia.org/wiki/National_identification_number) like the SSN for US and Canada. Should this be a locale or something? :confused: 
