### PR TITLE
Fix typo in README customization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ and you can then override or add elements to suit
 en-au-ocker:
   faker:
     name:
-      # Exiting faker field, new data
+      # Existing faker field, new data
       first_name: [Charlotte, Ava, Chloe, Emily]
 
       # New faker fields


### PR DESCRIPTION
Fix typo: 'exiting' => 'existing' when describing how to use I18n gem to customize fields.