### PR TITLE
Canadian Postcodes also can not start with DFIOQ or U

### DIFF
--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -1,7 +1,7 @@
 en-CA:
   faker:
     address:
-      postcode: /[A-VX-Y][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
+      postcode: /[A-CEJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
       state: [Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Northwest Territories, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan, Yukon]
       state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YK"]
       default_country: [Canada]


### PR DESCRIPTION
From http://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes

"Postal codes do not include the letters D, F, I, O, Q or U, and the
first position also does not make use of the letters W or Z"

I believe the previous version of this code misunderstood and read the above as "first position can only not have letters W or Z"
