### PR TITLE
Add image sets option in Faker::Avatar

### DIFF
--- a/lib/faker/avatar.rb
+++ b/lib/faker/avatar.rb
@@ -3,11 +3,11 @@ module Faker
     class << self
       SUPPORTED_FORMATS = %w(png jpg bmp)
 
-      def image(slug = nil, size = '300x300', format = 'png')
+      def image(slug = nil, size = '300x300', format = 'png', set = 'set1')
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
         slug ||= Faker::Lorem.words.join
-        "http://robohash.org/#{slug}.#{format}?size=#{size}"
+        "http://robohash.org/#{slug}.#{format}?size=#{size}&set=#{set}"
       end
     end
   end

--- a/test/test_avatar.rb
+++ b/test/test_avatar.rb
@@ -14,7 +14,7 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_correct_size
-    assert @tester.image('faker', '150x320').match(/http:\/\/robohash\.org\/faker\.png\?size=(.+)/)[1] == '150x320'
+    assert @tester.image('faker', '150x320').match(/http:\/\/robohash\.org\/faker\.png\?size=(.+)&.*/)[1] == '150x320'
   end
 
   def test_avatar_with_incorrect_size
@@ -33,4 +33,7 @@ class TestFakerAvatar < Test::Unit::TestCase
     end
   end
 
+  def test_avatar_with_set
+    assert @tester.image('faker', '300x300', 'jpg', 'set2').match(/http:\/\/robohash\.org\/faker\.jpg.*set=set2/)
+  end
 end


### PR DESCRIPTION
Recently saw the robohash.org website. It seems there are three sets of avatars -- the robots, the monsters and the disembodied heads. So added an option in Faker::Avatar.image method (as an optional last parameter). 

Also created a test case for checking whether the test option works and modified the test_avatar_with_correct_size test to make way for the '&' that comes as a result of including the set as a field in the GET request.