### PR TITLE
Remove `warning: ambiguous first argument; put parentheses or a space even after `/' operator`

### DIFF
--- a/test/test_faker_bitcoin.rb
+++ b/test/test_faker_bitcoin.rb
@@ -7,8 +7,8 @@ class TestFakerBitcoin < Test::Unit::TestCase
   end
 
   def test_testnet_address
-    assert_match /\A[mn][1-9A-Za-z]{32,34}\Z/, Faker::Bitcoin.testnet_address
-    assert_not_match /[OIl]/, Faker::Bitcoin.testnet_address
+    assert_match(/\A[mn][1-9A-Za-z]{32,34}\Z/, Faker::Bitcoin.testnet_address)
+    assert_not_match(/[OIl]/, Faker::Bitcoin.testnet_address)
   end
 
 end


### PR DESCRIPTION
Ambiguous first arguments warnings occure when I execute rake test command in Ruby 2.2.1p85.