### PR TITLE
Remove extra space from hacker.ingverb

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -143,9 +143,9 @@ en:
     hacker:
       abbreviation: [TCP,HTTP,SDD,RAM,GB,CSS,SSL,AGP,SQL,FTP,PCI,AI,ADP,RSS,XML,EXE,COM,HDD,THX,SMTP,SMS,USB,PNG,SAS,IB,SCSI,JSON,XSS,JBOD]
       adjective: [auxiliary,primary,back-end,digital,open-source,virtual,cross-platform,redundant,online,haptic,multi-byte,bluetooth,wireless,1080p,neural, optical,solid state,mobile]
-      noun: [driver,protocol,bandwidth,panel,microchip,program,port,card,array, interface,system,sensor,firewall,hard drive,pixel,alarm,feed,monitor,application,transmitter,bus,circuit,capacitor,matrix]
+      noun: [driver,protocol,bandwidth,panel,microchip,program,port,card,array,interface,system,sensor,firewall,hard drive,pixel,alarm,feed,monitor,application,transmitter,bus,circuit,capacitor,matrix]
       verb: [back up,bypass,hack,override,compress,copy,navigate,index,connect,generate,quantify,calculate,synthesize,input,transmit,program,reboot,parse]
-      ingverb: [backing up,bypassing,hacking,overriding,compressing,copying, navigating,indexing,connecting,generating,quantifying,calculating, synthesizing,transmitting,programming,parsing]
+      ingverb: [backing up,bypassing,hacking,overriding,compressing,copying,navigating,indexing,connecting,generating,quantifying,calculating, synthesizing,transmitting,programming,parsing]
 
     app:
       name: ['Redhold', 'Treeflex', 'Trippledex', 'Kanlam', 'Bigtax', 'Daltfresh', 'Toughjoyfax', 'Mat Lam Tam', 'Otcom', 'Tres-Zap', 'Y-Solowarm', 'Tresom', 'Voltsillam', 'Biodex', 'Greenlam', 'Viva', 'Matsoft', 'Temp', 'Zoolab', 'Subin', 'Rank', 'Job', 'Stringtough', 'Tin', 'It', 'Home Ing', 'Zamit', 'Sonsing', 'Konklab', 'Alpha', 'Latlux', 'Voyatouch', 'Alphazap', 'Holdlamis', 'Zaam-Dox', 'Sub-Ex', 'Quo Lux', 'Bamity', 'Ventosanzap', 'Lotstring', 'Hatity', 'Tempsoft', 'Overhold', 'Fixflex', 'Konklux', 'Zontrax', 'Tampflex', 'Span', 'Namfix', 'Transcof', 'Stim', 'Fix San', 'Sonair', 'Stronghold', 'Fintone', 'Y-find', 'Opela', 'Lotlux', 'Ronstring', 'Zathin', 'Duobam', 'Keylex']


### PR DESCRIPTION
Seems like spaces here are against convention

cc @sjzhu