### PR TITLE
Add random sport for teams in en and en-AU locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Faker::SlackEmoji.emoji #=> ":last_quarter_moon:"
 ###Faker::Team
 -----------------
 
-ruby ```
+```ruby
 
 # Random Team Creature
 Faker::Team.creature #=> "gooses"

--- a/README.md
+++ b/README.md
@@ -445,6 +445,22 @@ Faker::SlackEmoji.emoji #=> ":last_quarter_moon:"
 
 ```
 
+###Faker::Team
+-----------------
+
+ruby ```
+
+# Random Team Creature
+Faker::Team.creature #=> "gooses"
+
+# Random Team Name created from random US State (Faker::Address.state) prepended to a random Team Creature
+Faker::Team.name #=> "Oregon vixens"
+
+# Random Team Sport
+Faker::Team.sport #=> "lacrosse"
+
+```
+
 Customization
 ------------
 Since you may want to make addresses and other types of data look different

--- a/lib/locales/en-AU.yml
+++ b/lib/locales/en-AU.yml
@@ -20,3 +20,5 @@ en-AU:
       default_country: [Australia]
     phone_number:
       formats: ['0# #### ####', '+61 # #### ####', '04## ### ###', '+61 4## ### ###'] #iOS AUS phone formats
+    team:
+      sport: ['basketball', 'football', 'footy', 'netball', 'rugby']

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -139,7 +139,7 @@ en:
       creature: ['ants', 'bats', 'bears', 'bees', 'birds', 'buffalo', 'cats', 'chickens', 'cattle', 'dogs', 'dolphins', 'ducks', 'elephants', 'fishes', 'foxes', 'frogs', 'geese', 'goats', 'horses', 'kangaroos', 'lions', 'monkeys', 'owls', 'oxen', 'penguins', 'people', 'pigs', 'rabbits', 'sheep', 'tigers', 'whales', 'wolves', 'zebras', 'banshees', 'crows', 'black cats', 'chimeras', 'ghosts', 'conspirators', 'dragons', 'dwarves', 'elves', 'enchanters', 'exorcists', 'sons', 'foes', 'giants', 'gnomes', 'goblins', 'gooses', 'griffins', 'lycanthropes', 'nemesis', 'ogres', 'oracles', 'prophets', 'sorcerors', 'spiders', 'spirits', 'vampires', 'warlocks', 'vixens', 'werewolves', 'witches', 'worshipers', 'zombies', 'druids']
       name:
         - "#{Address.state} #{creature}"
-      sport: ['baseball', 'basketball', 'football', 'ice hockey', 'rugby', 'lacrosse', 'soccor']
+      sport: ['baseball', 'basketball', 'football', 'hockey', 'rugby', 'lacrosse', 'soccer']
 
     hacker:
       abbreviation: [TCP,HTTP,SDD,RAM,GB,CSS,SSL,AGP,SQL,FTP,PCI,AI,ADP,RSS,XML,EXE,COM,HDD,THX,SMTP,SMS,USB,PNG,SAS,IB,SCSI,JSON,XSS,JBOD]

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -139,6 +139,7 @@ en:
       creature: ['ants', 'bats', 'bears', 'bees', 'birds', 'buffalo', 'cats', 'chickens', 'cattle', 'dogs', 'dolphins', 'ducks', 'elephants', 'fishes', 'foxes', 'frogs', 'geese', 'goats', 'horses', 'kangaroos', 'lions', 'monkeys', 'owls', 'oxen', 'penguins', 'people', 'pigs', 'rabbits', 'sheep', 'tigers', 'whales', 'wolves', 'zebras', 'banshees', 'crows', 'black cats', 'chimeras', 'ghosts', 'conspirators', 'dragons', 'dwarves', 'elves', 'enchanters', 'exorcists', 'sons', 'foes', 'giants', 'gnomes', 'goblins', 'gooses', 'griffins', 'lycanthropes', 'nemesis', 'ogres', 'oracles', 'prophets', 'sorcerors', 'spiders', 'spirits', 'vampires', 'warlocks', 'vixens', 'werewolves', 'witches', 'worshipers', 'zombies', 'druids']
       name:
         - "#{Address.state} #{creature}"
+      sport: ['baseball', 'basketball', 'football', 'ice hockey', 'rugby', 'lacrosse', 'soccor']
 
     hacker:
       abbreviation: [TCP,HTTP,SDD,RAM,GB,CSS,SSL,AGP,SQL,FTP,PCI,AI,ADP,RSS,XML,EXE,COM,HDD,THX,SMTP,SMS,USB,PNG,SAS,IB,SCSI,JSON,XSS,JBOD]

--- a/test/test_faker_team.rb
+++ b/test/test_faker_team.rb
@@ -10,4 +10,8 @@ class TestFakerTeam < Test::Unit::TestCase
     assert @tester.name.match(/(\w+\.? ?){2}/)
   end
 
+  def test_sport
+    assert @tester.sport.match(/(\w+\.? ?){2}/)
+  end
+
 end

--- a/test/test_faker_team.rb
+++ b/test/test_faker_team.rb
@@ -11,7 +11,7 @@ class TestFakerTeam < Test::Unit::TestCase
   end
 
   def test_sport
-    assert @tester.sport.match(/(\w+\.? ?){2}/)
+    assert @tester.sport.match(/(\w+\.?){1}/)
   end
 
 end


### PR DESCRIPTION
This pull adds the ability to assign a random sport using `Faker::Team.sport` and comes with a passing test.