### PR TITLE
[DOCS] Add warning to README regarding non-unique return values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ for the creation of this gem), having real-looking test data, and having your
 database populated with more than one or two records while you're doing
 development.
 
+NOTE: While Faker generates data at random, returned values are not guaranteed to be unique.
+
 Installing
 ----------
 ```bash


### PR DESCRIPTION
Currently, there is no warning in the README that values returned by Faker are not guaranteed, and are not likely to be, unique. As a tool often used for integration testing, it should be clear that the values returned should not be used deterministically. 

This partially addresses the concern in: https://github.com/stympy/faker/issues/251