### PR TITLE
Updated README.md for "Faker::Company" usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Faker::Company.suffix #=> "Group"
 # Generate a buzzword-laden catch phrase.
 Faker::Company.catch_phrase #=> "Business-focused coherent parallelism"
 
+Faker::Company.buzzword #=> "Business-focused"
+
 # When a straight answer won't do, BS to the rescue!
 Faker::Company.bs #=> "empower one-to-one web-readiness"
 
@@ -138,6 +140,8 @@ Faker::Company.duns_number #=> "08-341-3736"
 
 # Get a random company logo url in PNG format.
 Faker::Company.logo #=> "http://pigment.github.com/fake-logos/logos/medium/color/5.png"
+
+Faker::Company.swedish_organisation_number #=> "7718797652"
 
 ```
 


### PR DESCRIPTION
Hi!

I updated README.md for `Faker::Company` usage, because I found 2 methods are missing.

* `.buzzword` : https://github.com/stympy/faker/pull/353
* `. swedish_organisation_number` : https://github.com/stympy/faker/pull/331

Thank you so much.