### PR TITLE
Fixed "Faker::Team.state"

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,9 @@ Faker::Team.creature #=> "gooses"
 # Random Team Name created from random US State (Faker::Address.state) prepended to a random Team Creature
 Faker::Team.name #=> "Oregon vixens"
 
+# Random Team State
+Faker::Team.state #=> "Oregon"
+
 # Random Team Sport
 Faker::Team.sport #=> "lacrosse"
 

--- a/lib/faker/team.rb
+++ b/lib/faker/team.rb
@@ -12,7 +12,7 @@ module Faker
       end
 
       def state
-        fetch('faker.address.state').titleize
+        fetch('address.state')
       end
     end
 

--- a/test/test_faker_team.rb
+++ b/test/test_faker_team.rb
@@ -10,8 +10,16 @@ class TestFakerTeam < Test::Unit::TestCase
     assert @tester.name.match(/(\w+\.? ?){2}/)
   end
 
+  def test_creature
+    assert @tester.creature.match(/(\w+){1}/)
+  end
+
+  def test_state
+    assert @tester.state.match(/(\w+){1}/)
+  end
+
   def test_sport
-    assert @tester.sport.match(/(\w+\.?){1}/)
+    assert @tester.sport.match(/(\w+){1}/)
   end
 
 end


### PR DESCRIPTION
I found that `Faker::Team.state` has error like this.
So, I fixed it and added some specs.

```ruby
>> Faker::Team.state
I18n::MissingTranslationData: translation missing: en.faker.faker.address.state
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n.rb:311:in `handle_exception'
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n.rb:161:in `translate'
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/faker-1.4.3/lib/faker.rb:128:in `rescue in translate'
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/faker-1.4.3/lib/faker.rb:120:in `translate'
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/faker-1.4.3/lib/faker.rb:86:in `fetch'
	from /Users/kakakakakku/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/faker-1.4.3/lib/faker/team.rb:15:in `state'
	from (irb):7
	from /Users/kakakakakku/.rbenv/versions/2.1.5/bin/irb:11:in `<main>'
```