### PR TITLE
Extends Business.credit_card_type

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -134,7 +134,7 @@ en:
     business:
       credit_card_numbers: ['1234-2121-1221-1211', '1212-1221-1121-1234', '1211-1221-1234-2201', '1228-1221-1221-1431']
       credit_card_expiry_dates: ['2011-10-12', '2012-11-12', '2015-11-11', '2013-9-12']
-      credit_card_types: ['visa', 'mastercard', 'americanexpress', 'discover']
+      credit_card_types: ['visa', 'mastercard', 'american_express', 'discover', 'diners_club', 'jcb', 'switch', 'solo', 'dankort', maestro', 'forbrugsforeningen', 'laser']
 
     commerce:
       color: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]


### PR DESCRIPTION
This commits seeks to standardize the values of **Faker::Finance.credit_card** accepted values with those returned by **Faker::Business.credit_card_type**. The reason is that I was trying to generate both Credit Card type and number in the following way:

```
    credit_card_type { Faker::Business.credit_card_type }
    credit_card_number { Faker::Finance.credit_card("#{credit_card_type}") }
```

and the following error ocurred: 

```
I18n::MissingTranslationData: translation missing: en.faker.credit_card.americanexpress
```

because the value returned by *credit_card_type* does not have the '_' in between american_express. 

Hope this helps.