### PR TITLE
Use HTTPS in external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Faker::Company.ein #=> "34-8488813"
 Faker::Company.duns_number #=> "08-341-3736"
 
 # Get a random company logo url in PNG format.
-Faker::Company.logo #=> "http://pigment.github.com/fake-logos/logos/medium/color/5.png"
+Faker::Company.logo #=> "https://pigment.github.com/fake-logos/logos/medium/color/5.png"
 
 Faker::Company.swedish_organisation_number #=> "7718797652"
 
@@ -289,15 +289,15 @@ Faker::Name.title #=> "Legacy Creative Director"
 
 ```ruby
 
-Faker::Avatar.image #=> "http://robohash.org/sitsequiquia.png?size=300x300"
+Faker::Avatar.image #=> "https://robohash.org/sitsequiquia.png?size=300x300"
 
-Faker::Avatar.image("my-own-slug") #=> "http://robohash.org/my-own-slug.png?size=300x300"
+Faker::Avatar.image("my-own-slug") #=> "https://robohash.org/my-own-slug.png?size=300x300"
 
-Faker::Avatar.image("my-own-slug", "50x50") #=> "http://robohash.org/my-own-slug.png?size=50x50"
+Faker::Avatar.image("my-own-slug", "50x50") #=> "https://robohash.org/my-own-slug.png?size=50x50"
 
-Faker::Avatar.image("my-own-slug", "50x50", "jpg") #=> "http://robohash.org/my-own-slug.jpg?size=50x50"
+Faker::Avatar.image("my-own-slug", "50x50", "jpg") #=> "https://robohash.org/my-own-slug.jpg?size=50x50"
 
-Faker::Avatar.image("my-own-slug", "50x50", "bmp") #=> "http://robohash.org/my-own-slug.bmp?size=50x50"
+Faker::Avatar.image("my-own-slug", "50x50", "bmp") #=> "https://robohash.org/my-own-slug.bmp?size=50x50"
 ```
 
 ###Faker::Number

--- a/lib/faker/avatar.rb
+++ b/lib/faker/avatar.rb
@@ -7,7 +7,7 @@ module Faker
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
         slug ||= Faker::Lorem.words.join
-        "http://robohash.org/#{slug}.#{format}?size=#{size}&set=#{set}"
+        "https://robohash.org/#{slug}.#{format}?size=#{size}&set=#{set}"
       end
     end
   end

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -36,7 +36,7 @@ module Faker
       # Get a random company logo url in PNG format.
       def logo
         rand_num = Random.rand(13) + 1
-        "http://pigment.github.io/fake-logos/logos/medium/color/#{rand_num}.png"
+        "https://pigment.github.io/fake-logos/logos/medium/color/#{rand_num}.png"
       end
 
       def swedish_organisation_number

--- a/test/test_avatar.rb
+++ b/test/test_avatar.rb
@@ -6,15 +6,15 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar
-    assert @tester.image.match(/http:\/\/robohash\.org\/(.+)\.png/)[1] != nil
+    assert @tester.image.match(/https:\/\/robohash\.org\/(.+)\.png/)[1] != nil
   end
 
   def test_avatar_with_param
-    assert @tester.image('faker').match(/http:\/\/robohash\.org\/(.+)\.png/)[1] == 'faker'
+    assert @tester.image('faker').match(/https:\/\/robohash\.org\/(.+)\.png/)[1] == 'faker'
   end
 
   def test_avatar_with_correct_size
-    assert @tester.image('faker', '150x320').match(/http:\/\/robohash\.org\/faker\.png\?size=(.+)&.*/)[1] == '150x320'
+    assert @tester.image('faker', '150x320').match(/https:\/\/robohash\.org\/faker\.png\?size=(.+)&.*/)[1] == '150x320'
   end
 
   def test_avatar_with_incorrect_size
@@ -24,7 +24,7 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image('faker', '300x300', 'jpg').match(/http:\/\/robohash\.org\/faker\.jpg/)
+    assert @tester.image('faker', '300x300', 'jpg').match(/https:\/\/robohash\.org\/faker\.jpg/)
   end
 
   def test_avatar_with_incorrect_format
@@ -34,6 +34,6 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_set
-    assert @tester.image('faker', '300x300', 'jpg', 'set2').match(/http:\/\/robohash\.org\/faker\.jpg.*set=set2/)
+    assert @tester.image('faker', '300x300', 'jpg', 'set2').match(/https:\/\/robohash\.org\/faker\.jpg.*set=set2/)
   end
 end

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -14,7 +14,7 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def test_logo
-    assert @tester.logo.match(%r{http://pigment.github.io/fake-logos/logos/medium/color/\d+\.png})
+    assert @tester.logo.match(%r{https://pigment.github.io/fake-logos/logos/medium/color/\d+\.png})
   end
 
   def test_buzzword


### PR DESCRIPTION
Insecure content warning occurred by robohash and company logo's url in HTTPS web site.
I think that's better to use https in any external resources.