### PR TITLE
Feature: switch locale to en temporarily when using Faker::Internet user_name/domain_name with zh-TW locale

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -186,3 +186,4 @@ require 'extensions/array'
 require 'extensions/symbol'
 
 require 'helpers/char'
+require 'helpers/locale_switcher'

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -58,7 +58,9 @@ module Faker
       end
 
       def domain_name
-        [Char.prepare(domain_word), domain_suffix].join('.')
+        I18n.with_locale(LocaleSwitcher.switch(:internet)) do
+          [Char.prepare(domain_word), domain_suffix].join('.')
+        end
       end
 
       def fix_umlauts(string)

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -15,33 +15,35 @@ module Faker
       end
 
       def user_name(specifier = nil, separators = %w(. _))
-        if specifier.kind_of? String
-          return specifier.scan(/\w+/).shuffle.join(separators.sample).downcase
-        elsif specifier.kind_of? Integer
-          tries = 0 # Don't try forever in case we get something like 1_000_000.
-          begin
-            result = user_name nil, separators
-            tries += 1
-          end while result.length < specifier and tries < 7
-          until result.length >= specifier
-            result = result * 2
+        I18n.with_locale(LocaleSwitcher.switch(:internet)) do
+          if specifier.kind_of? String
+            return specifier.scan(/\w+/).shuffle.join(separators.sample).downcase
+          elsif specifier.kind_of? Integer
+            tries = 0 # Don't try forever in case we get something like 1_000_000.
+            begin
+              result = user_name nil, separators
+              tries += 1
+            end while result.length < specifier and tries < 7
+            until result.length >= specifier
+              result = result * 2
+            end
+            return result
+          elsif specifier.kind_of? Range
+            tries = 0
+            begin
+              result = user_name specifier.min, separators
+              tries += 1
+            end while not specifier.include? result.length and tries < 7
+            return result[0...specifier.max]
           end
-          return result
-        elsif specifier.kind_of? Range
-          tries = 0
-          begin
-            result = user_name specifier.min, separators
-            tries += 1
-          end while not specifier.include? result.length and tries < 7
-          return result[0...specifier.max]
-        end
 
-        [
-          Char.prepare(Name.first_name),
-          [Name.first_name, Name.last_name].map{ |name|
-            Char.prepare name
-          }.join(separators.sample)
-        ].sample
+          [
+            Char.prepare(Name.first_name),
+            [Name.first_name, Name.last_name].map{ |name|
+              Char.prepare name
+            }.join(separators.sample)
+          ].sample
+        end
       end
 
       def password(min_length = 8, max_length = 16)

--- a/lib/helpers/locale_switcher.rb
+++ b/lib/helpers/locale_switcher.rb
@@ -4,8 +4,8 @@ module Faker
       switched_locale = Faker::Config.locale
       case type
       when :internet
-        if Faker::Config.locale == "zh-TW"
-          switched_locale = "en"
+        if Faker::Config.locale == :"zh-TW"
+          switched_locale = :en
         end
       end
       switched_locale

--- a/lib/helpers/locale_switcher.rb
+++ b/lib/helpers/locale_switcher.rb
@@ -1,0 +1,14 @@
+module Faker
+  module LocaleSwitcher
+    def self.switch(type)
+      switched_locale = Faker::Config.locale
+      case type
+      when :internet
+        if Faker::Config.locale == "zh-TW"
+          switched_locale = "en"
+        end
+      end
+      switched_locale
+    end
+  end
+end

--- a/test/test_locale_switcher.rb
+++ b/test/test_locale_switcher.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestLocaleSwitcher < Test::Unit::TestCase
+  def test_internet_zh_tw_to_en
+    Faker::Config.locale = "zh-TW"
+    assert Faker::LocaleSwitcher.switch(:internet) == "en"
+  end
+end

--- a/test/test_locale_switcher.rb
+++ b/test/test_locale_switcher.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
 class TestLocaleSwitcher < Test::Unit::TestCase
   def test_internet_zh_tw_to_en
-    Faker::Config.locale = "zh-TW"
-    assert Faker::LocaleSwitcher.switch(:internet) == "en"
+    Faker::Config.locale = :"zh-TW"
+    assert Faker::LocaleSwitcher.switch(:internet) == :en
   end
 end


### PR DESCRIPTION
# Issue

When using Faker with locale zh-TW, empty strings are generated with `Faker::Internet.user_name` and `Faker::Internet.domain_name`. It causes most of faked emails are invalid.

```
I18n.locale = :"zh-TW"
Faker::Internet.user_name # ""
Faker::Internet.domain_name # ".io"
Faker::Internet.email # "@.name" 
```

# Solution

Use `I18n.with_locale` and `Fake::LocaleSwicher` to handle which locale should be used when using a type of Faker with a particular locale. For now, only zh-TW is supported, but it should be easy to extend for other locales.