### PR TITLE
Fixed error for birthday spec

### DIFF
--- a/test/test_faker_date.rb
+++ b/test/test_faker_date.rb
@@ -58,10 +58,11 @@ class TestFakerDate < Test::Unit::TestCase
       date_min = Date.new(t.year - min, t.month, t.day)
       date_max = Date.new(t.year - max, t.month, t.day)
       birthday = @tester.birthday(min, max)
-      assert birthday > date_max, "Expect > \"#{date_max}\", but got #{birthday}"
-      assert birthday < date_min, "Expect > \"#{date_max}\", but got #{birthday}"
+      assert birthday >= date_max, "Expect > \"#{date_max}\", but got #{birthday}"
+      assert birthday <= date_min, "Expect > \"#{date_max}\", but got #{birthday}"
     end
   end
+
   def test_default_birthday
     min = 10
     max = 65
@@ -70,7 +71,7 @@ class TestFakerDate < Test::Unit::TestCase
       date_min = Date.new(t.year - min, t.month, t.day)
       date_max = Date.new(t.year - max, t.month, t.day)
       birthday = @tester.birthday
-      assert birthday > date_max, "Expect > \"#{date_max}\", but got #{birthday}"
+      assert birthday >= date_max, "Expect > \"#{date_max}\", but got #{birthday}"
       assert birthday < date_min, "Expect > \"#{date_max}\", but got #{birthday}"
     end
   end


### PR DESCRIPTION
I found that sometimes error happen at `test/test_faker_date.rb`, especially `test_birthday` and `test_default_birthday` like this.

* [Improve ja locale by ohbarye · Pull Request #430 · stympy/faker](https://github.com/stympy/faker/pull/430)

This is rare case and almost success because `100.times` randomly.
Only `@tester.birthday` returned min date or max date.

I tried `10000.times` randomly, same error happened.

```ruby
Failure:
  Expect > "1925-10-10", but got 1975-10-10.
  <false> is not true.
test_birthday(TestFakerDate)
/xxx/faker/test/test_faker_date.rb:62:in `block in test_birthday'
/xxx/faker/test/test_faker_date.rb:56:in `times'
/xxx/faker/test/test_faker_date.rb:56:in `test_birthday'
     53:   def test_birthday
     54:     min = 40
     55:     max = 90
  => 56:     10000.times do
     57:       t = Date.today
     58:       date_min = Date.new(t.year - min, t.month, t.day)
     59:       date_max = Date.new(t.year - max, t.month, t.day)
===============================================================================
F
===============================================================================
Failure:
  Expect > "1950-10-10", but got 1950-10-10.
  <false> is not true.
test_default_birthday(TestFakerDate)
/xxx/faker/test/test_faker_date.rb:73:in `block in test_default_birthday'
/xxx/faker/test/test_faker_date.rb:68:in `times'
/xxx/faker/test/test_faker_date.rb:68:in `test_default_birthday'
     65:   def test_default_birthday
     66:     min = 10
     67:     max = 65
  => 68:     10000.times do
     69:       t = Date.today
     70:       date_min = Date.new(t.year - min, t.month, t.day)
     71:       date_max = Date.new(t.year - max, t.month, t.day)
===============================================================================
```

Here is my rough memo.

![memo](https://cloud.githubusercontent.com/assets/1573290/10411673/32a7cd90-6fa8-11e5-8e8a-de826f2424f7.png)

Thanks!!!