### PR TITLE
pop the options hash again before pushing it again

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -122,10 +122,13 @@ module Faker
         opts[:raise] = true
         I18n.translate(*(args.push(opts)))
       rescue I18n::MissingTranslationData
+        opts = args.last.is_a?(Hash) ? args.pop : {}
+        opts[:locale] = :en
+
         # Super-simple fallback -- fallback to en if the
         # translation was missing.  If the translation isn't
         # in en either, then it will raise again.
-        I18n.translate(*(args.push(opts.merge(:locale => :en))))
+        I18n.translate(*(args.push(opts)))
       end
 
       def flexible(key)


### PR DESCRIPTION
In case of an `I18n::MissingTranslationData` exception, there might already be an options hash passed into `I18n.translate`. When that's the case, calling `args.push(opts)` will result in three arguments: `key`, `options hash from line 120`, `options hash from args.push(opts)`. This PR prevents that case from happening by resetting popping the last argument if it's a hash and manually setting the locale.