### PR TITLE
Fixed Faker::Book.author not parsing Name.name

### DIFF
--- a/lib/faker/book.rb
+++ b/lib/faker/book.rb
@@ -8,7 +8,7 @@ module Faker
       end
 
       def author
-        fetch('book.author')
+        parse('book.author')
       end
 
       def publisher


### PR DESCRIPTION
Calling Faker::Book.author returns "Name.name" literal string.