### PR TITLE
Allow Faker::Commerce #price method to use srand value.

### DIFF
--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -28,7 +28,7 @@ module Faker
       end
 
       def price(range=0..100.0)
-        random = Random.new
+        random = Random::DEFAULT
         (random.rand(range) * 100).floor/100.0
       end
 

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -5,15 +5,15 @@ class TestFakerCommerce < Test::Unit::TestCase
   def setup
     @tester = Faker::Commerce
   end
-  
+
   def test_color
     assert @tester.color.match(/[a-z]+\.?/)
   end
-  
+
   def test_department
     assert @tester.department.match(/[A-Z][a-z]+\.?/)
   end
-  
+
   def test_single_department_should_not_contain_separators
     assert_match(/\A[A-Za-z]+\z/, @tester.department(1))
   end
@@ -68,6 +68,11 @@ class TestFakerCommerce < Test::Unit::TestCase
     assert_instance_of Float, @tester.price(5..6)
     assert_includes 5..6, @tester.price(5..6)
     assert_includes 990...1000, @tester.price(990...1000)
+  end
+
+  def test_price_with_srand
+    srand(12345)
+    assert_equal 92.96, @tester.price
   end
 
   def test_price_is_float


### PR DESCRIPTION
Often times, I'll be using Faker for seeding my database during development.

One thing that I have noticed is that for many methods, using the `Random.srand` method to set the seed and generate the same random data every time, but does not work with the Faker::Commerce.price method.

This change is small, but allows the `price` method to use the `srand` seed if it's been set. Random::DEFAULT is just any random seed if you don't use `srand` to set it, so if a user uses the `price` method without using `srand` to preset a seed, there should be no change in behavior (and this change does not break any tests that already exist).