### PR TITLE
Added Faker::Job with title, field and key skills

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -188,6 +188,7 @@ require 'faker/slack_emoji'
 require 'faker/book'
 require 'faker/hipster'
 require 'faker/shakespeare'
+require 'faker/job'
 
 require 'extensions/array'
 require 'extensions/symbol'

--- a/lib/faker/job.rb
+++ b/lib/faker/job.rb
@@ -1,0 +1,16 @@
+module Faker
+  class Job < Base
+    flexible :job
+
+    class << self
+
+      def title
+        parse('job.title')
+      end
+
+      def field;     fetch('job.field'); end
+      def key_skill; fetch('job.key_skills'); end
+
+    end
+  end
+end

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -197,3 +197,15 @@ en:
       author: "#{Name.name}"
       publisher: ['Parker Publishing', 'Page Crunch', 'Word Burner', 'Printed Works', 'Opus Reader', 'Booklet', 'Offprint', 'Bookfolio', 'Book Crunch', 'Page Feeder']
       genre: ['Classic', 'Comic/Graphic Novel', 'Crime/Detective', 'Fable', 'Fairy tale', 'Fanfiction', 'Fantasy', 'Fiction narrative', 'Fiction in verse', 'Folklore', 'Historical fiction', 'Horror', 'Humor', 'Legend', 'Metafiction', 'Mystery', 'Mythology', 'Mythopoeia', 'Realistic fiction', 'Science fiction ', 'Short story', 'Suspense/Thriller', 'Tall tale', 'Western', 'Biography/Autobiography', 'Essay', 'Narrative nonfiction', 'Speech', 'Textbook', 'Reference book']
+
+    job:
+      field: [Marketing, IT, Accounting, Administration, Advertising, Banking, Community-Services, Construction, Consulting, Design, Education, Farming, Government, Healthcare, Hospitality, Legal, Manufacturing, Marketing, Mining, Real-Estate, Retail, Sales, Technology]
+      seniority: [Lead, Senior, Product, National, Regional, District, Central, Global, Customer, Investor, Dynamic, International, Legacy, Forward, Internal, Chief]
+      position: [Supervisor, Associate, Executive, Liaison, Officer, Manager, Engineer, Specialist, Director, Coordinator, Administrator, Architect, Analyst, Designer, Planner, Orchestrator, Technician, Developer, Producer, Consultant, Assistant, Facilitator, Agent, Representative, Strategist]
+      key_skills: [Teamwork, Communication, Problem solving, Leadership, Organisation, Work under pressure, Confidence, Self-motivated, Networking skills, Proactive, Fast learner, Technical savvy]
+      title:
+        - "#{seniority} #{field} #{position}"
+        - "#{seniority} #{field} #{position}"
+        - "#{field} #{position}"
+        - "#{field} #{position}"
+        - "#{seniority} #{position}"

--- a/test/test_faker_job.rb
+++ b/test/test_faker_job.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerJob < Test::Unit::TestCase
+
+  def setup
+    @tester = Faker::Job
+  end
+
+  def test_title
+    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+  end
+
+  def test_field
+    assert @tester.field.match(/(\w+\.? ?)/)
+  end
+
+  def test_key_skill
+    assert @tester.key_skill.match(/(\w+\.? ?)/)
+  end
+end


### PR DESCRIPTION
I'm using Faker more and more to build out staging environments at work and have reached a point where it makes sense to extend it. 

I'd like to keep working on Faker::Job with more attributes such a description, salary ranges, responsibilities, work-type (full-time/part-time etc), location and anything else I can think of that would be useful.

I've used some of the information that en.yml/names.title used within my dataset; if this needs to change (either I change where I fetch the data from or generate my own) please let me know :smile: 