### PR TITLE
Implement Faker::Date.between_except

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Faker::Company.profession #=> "firefighter"
 # Random date between dates
 Faker::Date.between(2.days.ago, Date.today) #=> "Wed, 24 Sep 2014"
 
+# Randome date between dates except for certain date
+Faker::Date.between_except(1.year.ago, 1.year.from_now, Date.tody) #=> "Wed, 24 Sep 2014"
+
 # Random date in the future (up to maximum of N days)
 Faker::Date.forward(23) # => "Fri, 03 Oct 2014"
 

--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -8,6 +8,14 @@ module Faker
         Faker::Base::rand_in_range(from, to)
       end
 
+      def between_except(from, to, excepted)
+        begin
+          date = between(from, to)
+        end while date == excepted
+
+        date
+      end
+
       def forward(days = 365)
         from = ::Date.today + 1
         to   = ::Date.today + days

--- a/test/test_faker_date.rb
+++ b/test/test_faker_date.rb
@@ -16,6 +16,17 @@ class TestFakerDate < Test::Unit::TestCase
     end
   end
 
+  def test_between_except
+    from = Date.parse("2012-01-01")
+    to   = Date.parse("2012-01-05")
+    excepted = Date.parse("2012-01-03")
+
+    100.times do
+      random_date = @tester.between_except(from, to, excepted)
+      assert random_date != excepted, "Expected != \"#{excepted}\", but got #{random_date}"
+    end
+  end
+
   def test_forward
     today = Date.today
 


### PR DESCRIPTION
## What

`Faker::Date.between_except` returns a day except for a certain day. It is convenient for the test of a feature that should not get a certain day, like the function that should be run on a certain day.

When to implement a test, it can be like:

```ruby
  # ...
  context "not on today" do
    before do
      date = Faker::Date.between_except(1.week.ago, 1.week.from_now, Time.zone.today)
      # ...
    end
    it "should fail to access" do
      expect(page).not_to have_content "Order Page"
    end
```

## How to

```ruby
Faker::Date.between_except(1.year.ago, 1.year.from_now, Date.tody) 
#=> "Wed, 24 Sep 2014"
```