### PR TITLE
Faker::Color documentation and a color name method

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ Faker::Code.ean #=> "4600051000057"
 
 ```
 
+###Faker::Color
+---------------
+
+```ruby
+
+Faker::Color.hex_color #=> "#31a785"
+
+Faker::Color.color_name #=> "yellow"
+
+Faker::Color.rgb_color #=> [54, 233, 67]
+
+Faker::Color.hsl_color #=> [69.87, 169.66, 225.3]
+
+Faker::Color.hsla_color #=> [154.77, 232.36, 58.9, 0.26170574657729073]
+
+
+```
+
 ###Faker::Commerce
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Faker::Color.hsl_color #=> [69.87, 169.66, 225.3]
 
 Faker::Color.hsla_color #=> [154.77, 232.36, 58.9, 0.26170574657729073]
 
-
 ```
 
 ###Faker::Commerce

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -5,6 +5,10 @@ module Faker
         @hex_color = "#%06x" % (rand * 0xffffff)
       end
 
+      def color_name
+        fetch('color.name')
+      end
+
       def single_rgb_color
         @single_rgb_color = (0..255).to_a.sample
         @single_rgb_color

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -3,7 +3,7 @@ module Faker
 
     class << self
       def color
-        fetch('commerce.color')
+        fetch('color.name')
       end
 
       def department(max = 3, fixed_amount = false)

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -141,8 +141,10 @@ en:
       credit_card_expiry_dates: ['2011-10-12', '2012-11-12', '2015-11-11', '2013-9-12']
       credit_card_types: ['visa', 'mastercard', 'american_express', 'discover', 'diners_club', 'jcb', 'switch', 'solo', 'dankort', maestro', 'forbrugsforeningen', 'laser']
 
+    color:
+      name: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]
+
     commerce:
-      color: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]
       department: ["Books", "Movies", "Music", "Games", "Electronics", "Computers", "Home", "Garden", "Tools", "Grocery", "Health", "Beauty", "Toys", "Kids", "Baby", "Clothing", "Shoes", "Jewelery", "Sports", "Outdoors", "Automotive", "Industrial"]
       product_name:
         adjective: [Small, Ergonomic, Rustic, Intelligent, Gorgeous, Incredible, Fantastic, Practical, Sleek, Awesome, Enormous, Mediocre, Synergistic, Heavy Duty, Lightweight, Aerodynamic, Durable]

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -5,6 +5,10 @@ class TestFakerColor < Test::Unit::TestCase
     @tester = Faker::Color
   end
 
+  def test_color_name
+    assert @tester.color_name.match(/[a-z]+\.?/)
+  end
+
   def test_hex_color
     assert @tester.hex_color.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
   end


### PR DESCRIPTION
Hey :wave: 

Looking through the issues I realised that there's been couple of requests for color functionality (such as #476). Also found that there's already code for random colors just they do not appear documented in the ReadMe so I've added some.

I only added documentation for some of the methods as I'm not sure if some of the methods such as `single_rgb_color` and `single_hsl_color` are as useful. Do you think it'd be worth including documentation for all of the public methods?

At the same time I felt that adding a method to `Faker::Color` that returns a random name of a color would be a good idea, I noticed that this already existed on the `Faker::Ecommerce` class so I refactored it to be part of the color class instead whilst leaving the functionality on ecommerce intact.

I added a simple test for the color name which is identical to the test that was already in place for it as part of the ecommerce class.

I hope you find this PR ok; I've tried to keep to the conventions and style I saw elsewhere in the code base.

Thanks,
.FxN

ps. Thanks so much for maintaining this it's such a great helper :heart: 