### PR TITLE
[ci-skip] Add note in the README to refer to user's version for available methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ for the creation of this gem), having real-looking test data, and having your
 database populated with more than one or two records while you're doing
 development.
 
-NOTE: While Faker generates data at random, returned values are not guaranteed to be unique.
+### NOTE
+
+* While Faker generates data at random, returned values are not guaranteed to be unique.
+* This is the `master` branch of Faker and may contain changes that are not yet released.
+  Please refer the README of your version for the available methods.
+  List of all versions is [available here](https://github.com/stympy/faker/releases).
 
 Installing
 ----------


### PR DESCRIPTION
Lot of people assume that all methods in the README on master branch are available. Examples are #496 and #505. Add a small note upfront saying that they should refer to README of their version and not the master branch.

Closes https://github.com/stympy/faker/issues/496 and https://github.com/stympy/faker/issues/505