### PR TITLE
Add msisdn format to phone_number

### DIFF
--- a/lib/faker/phone_number.rb
+++ b/lib/faker/phone_number.rb
@@ -17,6 +17,16 @@ module Faker
         end
       end
 
+      # for instance just to pt_BR
+      # see https://en.wikipedia.org/wiki/MSISDN
+      def msisdn
+        if parse('msisdn.formats') == ""
+          numerify(fetch('msisdn.formats'))
+        else
+          parse('msisdn.formats')
+        end
+      end
+
       # US only
       def area_code
         begin

--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -55,9 +55,8 @@ pt-BR:
 
     phone_number:
       area_code: ["11","12","13","14","15","16","17","18","19","21","22","24","27","28","31","32","33","34","35","37","38","41","42","43","44","45","46","47","48","49","51","53","54","55","61","62","63","64","65","66","67","68","69","71","73","74","75","77","79","81","82","83","84","85","86","87","88","89","91","92","93","94","95","96","97","98","99"]
-      formats: ["(#{PhoneNumber.area_code}) ####-####",
-                "+55 (#{PhoneNumber.area_code}) ####-####",
-                "(#{PhoneNumber.area_code}) #####-####"]
+      formats: ["(#{PhoneNumber.area_code}) #{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}",
+                "+55 (#{PhoneNumber.area_code}) #{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}"]
     cell_phone:
       formats:
         - "(#{PhoneNumber.area_code}) 9#{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}"

--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -28,7 +28,7 @@ pt-BR:
       street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
       secondary_address: ["Apto. ###", "Sobrado ##", "Casa #", "Lote ##", "Quadra ##"]
       # Though these are US-specific, they are here (in the default locale) for backwards compatibility
-      postcode: ["#####", "#####-###"]
+      postcode: ["#####-###"]
       state: ["Acre", "Alagoas", "Amapá", "Amazonas", "Bahia", "Ceará", "Distrito Federal", "Espírito Santo", "Goiás", "Maranhão", "Mato Grosso", "Mato Grosso do Sul", "Minas Gerais", "Pará", "Paraíba", "Paraná", "Pernambuco", "Piauí", "Rio de Janeiro", "Rio Grande do Norte", "Rio Grande do Sul", "Rondônia", "Roraima", "Santa Catarina", "São Paulo", "Sergipe", "Tocantins"]
       state_abbr: [AC, AL, AP, AM, BA, CE, DF, ES, GO, MA, MT, MS, PA, PB, PR, PE, PI, RJ, RN, RS, RO, RR, SC, SP]
       default_country: [Brasil]
@@ -54,4 +54,15 @@ pt-BR:
       suffix: ["Jr.", "Neto", "Filho"]
 
     phone_number:
-      formats: ["(##) ####-####", "+55 (##) ####-####", "(##) #####-####"]
+      area_code: ["11","12","13","14","15","16","17","18","19","21","22","24","27","28","31","32","33","34","35","37","38","41","42","43","44","45","46","47","48","49","51","53","54","55","61","62","63","64","65","66","67","68","69","71","73","74","75","77","79","81","82","83","84","85","86","87","88","89","91","92","93","94","95","96","97","98","99"]
+      formats: ["(#{PhoneNumber.area_code}) ####-####",
+                "+55 (#{PhoneNumber.area_code}) ####-####",
+                "(#{PhoneNumber.area_code}) #####-####"]
+    cell_phone:
+      formats:
+        - "(#{PhoneNumber.area_code}) 9#{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}"
+        - "+55 (#{PhoneNumber.area_code}) 9#{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}"
+        - "(#{PhoneNumber.area_code}) 9#{PhoneNumber.subscriber_number}-#{PhoneNumber.subscriber_number}"
+    msisdn:
+      formats:
+        - "#{PhoneNumber.area_code}9#{PhoneNumber.subscriber_number}#{PhoneNumber.subscriber_number}"

--- a/test/test_pt_br_locale.rb
+++ b/test/test_pt_br_locale.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TestPtLocale < Test::Unit::TestCase
+class TestPtBrLocale < Test::Unit::TestCase
   def setup
-    Faker::Config.locale = "pt"
+    Faker::Config.locale = 'pt-BR'
   end
 
   def teardown
@@ -14,14 +14,18 @@ class TestPtLocale < Test::Unit::TestCase
   end
 
   def test_pl_building_number
-    assert_match /^[\d]{3,5}$/, Faker::Address.building_number
+    assert_match /^[\d]{3,5}$|^s\/n$/, Faker::Address.building_number
   end
 
   def test_pl_post_code
-    assert_match /^[\d]{4}$/, Faker::Address.postcode
+    assert_match /^[\d]{5}-[\d]{3}$/, Faker::Address.postcode
   end
 
   def test_pl_secondary_address
     assert_match /^[[:word:]]+[\.]? \d{1,3}$/, Faker::Address.secondary_address
+  end
+
+  def test_validity_of_msisdn_method_output
+    assert_match(/^[\d]{11}$/, Faker::PhoneNumber.msisdn)
   end
 end


### PR DESCRIPTION
Added the method Faker::PhoneNumber.msisdn to simplify the use of phone number format in telecom issues. For instance, this cover only pt_br locale but can be merged to all others locales.