### PR TITLE
Added Faker::Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,15 @@ Faker::Beer.alcohol #=> "6.3%"
 Faker::Beer.blg #=> "18.5°Blg"
 ```
 
+###Faker::Job
 
+```ruby
+Faker::Job.title #=> "Lead Accounting Associate"
+
+Faker::Job.field #=> "Manufacturing"
+
+Faker::Job.key_skill #=> "Teamwork"
+```
 
 Customization
 ------------

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -207,6 +207,7 @@ require 'faker/superhero'
 require 'faker/beer'
 require 'faker/boolean'
 require 'faker/star_wars'
+require 'faker/job'
 
 require 'extensions/array'
 require 'extensions/symbol'

--- a/lib/faker/job.rb
+++ b/lib/faker/job.rb
@@ -1,0 +1,16 @@
+module Faker
+  class Job < Base
+    flexible :job
+
+    class << self
+
+      def title
+        parse('job.title')
+      end
+
+      def field;     fetch('job.field'); end
+      def key_skill; fetch('job.key_skills'); end
+
+    end
+  end
+end

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -222,3 +222,16 @@ en:
       yeast: ['1007 - German Ale', '1010 - American Wheat', '1028 - London Ale', '1056 - American Ale', '1084 - Irish Ale', '1098 - British Ale', '1099 - Whitbread Ale', '1187 - Ringwood Ale', '1272 - American Ale II', '1275 - Thames Valley Ale', '1318 - London Ale III', '1332 - Northwest Ale', '1335 - British Ale II', '1450 - Dennys Favorite 50', '1469 - West Yorkshire Ale', '1728 - Scottish Ale', '1968 - London ESB Ale', '2565 - Kölsch', '1214 - Belgian Abbey', '1388 - Belgian Strong Ale', '1762 - Belgian Abbey II', '3056 - Bavarian Wheat Blend', '3068 - Weihenstephan Weizen', '3278 - Belgian Lambic Blend', '3333 - German Wheat', '3463 - Forbidden Fruit', '3522 - Belgian Ardennes', '3638 - Bavarian Wheat', '3711 - French Saison', '3724 - Belgian Saison', '3763 - Roeselare Ale Blend', '3787 - Trappist High Gravity', '3942 - Belgian Wheat', '3944 - Belgian Witbier', '2000 - Budvar Lager', '2001 - Urquell Lager', '2007 - Pilsen Lager', '2035 - American Lager', '2042 - Danish Lager', '2112 - California Lager', '2124 - Bohemian Lager', '2206 - Bavarian Lager', '2278 - Czech Pils', '2308 - Munich Lager', '2633 - Octoberfest Lager Blend', '5112 - Brettanomyces bruxellensis', '5335 - Lactobacillus', '5526 - Brettanomyces lambicus', '5733 - Pediococcus']
       malt: ['Black malt', 'Caramel', 'Carapils', 'Chocolate', 'Munich', 'Caramel', 'Carapils', 'Chocolate malt', 'Munich', 'Pale', 'Roasted barley', 'Rye malt', 'Special roast', 'Victory', 'Vienna', 'Wheat mal']
       style: ["Light Lager", "Pilsner", "European Amber Lager", "Dark Lager", "Bock", "Light Hybrid Beer", "Amber Hybrid Beer", "English Pale Ale", "Scottish And Irish Ale", "Merican Ale", "English Brown Ale", "Porter", "Stout", "India Pale Ale", "German Wheat And Rye Beer", "Belgian And French Ale", "Sour Ale", "Belgian Strong Ale", "Strong Ale", "Fruit Beer", "Vegetable Beer", "Smoke-flavored", "Wood-aged Beer"]
+
+    job:
+      field: [Marketing, IT, Accounting, Administration, Advertising, Banking, Community-Services, Construction, Consulting, Design, Education, Farming, Government, Healthcare, Hospitality, Legal, Manufacturing, Marketing, Mining, Real-Estate, Retail, Sales, Technology]
+      seniority: [Lead, Senior, Product, National, Regional, District, Central, Global, Customer, Investor, Dynamic, International, Legacy, Forward, Internal, Chief]
+      position: [Supervisor, Associate, Executive, Liaison, Officer, Manager, Engineer, Specialist, Director, Coordinator, Administrator, Architect, Analyst, Designer, Planner, Orchestrator, Technician, Developer, Producer, Consultant, Assistant, Facilitator, Agent, Representative, Strategist]
+      key_skills: [Teamwork, Communication, Problem solving, Leadership, Organisation, Work under pressure, Confidence, Self-motivated, Networking skills, Proactive, Fast learner, Technical savvy]
+      title:
+        - "#{seniority} #{field} #{position}"
+        - "#{seniority} #{field} #{position}"
+        - "#{field} #{position}"
+        - "#{field} #{position}"
+        - "#{seniority} #{position}"
+

--- a/test/test_faker_job.rb
+++ b/test/test_faker_job.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerJob < Test::Unit::TestCase
+
+  def setup
+    @tester = Faker::Job
+  end
+
+  def test_title
+    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+  end
+
+  def test_field
+    assert @tester.field.match(/(\w+\.? ?)/)
+  end
+
+  def test_key_skill
+    assert @tester.key_skill.match(/(\w+\.? ?)/)
+  end
+end


### PR DESCRIPTION
I have added Faker::Job, which is used via;

``` ruby
Faker::Job.title #=> "Lead Accounting Associate"
Faker::Job.field #=> "Manufacturing"
Faker::Job.key_skill #=> "Teamwork"
```

Included as well are tests and an update to the README.md.
