### PR TITLE
Fix warnings in tests

### DIFF
--- a/test/test_da_dk_locale.rb
+++ b/test/test_da_dk_locale.rb
@@ -18,15 +18,15 @@ class TestDaDkLocale < Test::Unit::TestCase
   end
 
   def test_da_dk_phone_number
-    assert_match /(20)|(30)|(40)[\d\s]+$/, Faker::PhoneNumber.cell_phone
-    assert_match /(\d\d[\s\-]?){4}$/, Faker::PhoneNumber.phone_number
+    assert_match(/(20)|(30)|(40)[\d\s]+$/, Faker::PhoneNumber.cell_phone)
+    assert_match(/(\d\d[\s\-]?){4}$/, Faker::PhoneNumber.phone_number)
   end
 
   def test_da_dk_postal_code
-    assert_match /[\d]{4}$/, Faker::Address.postcode
+    assert_match(/[\d]{4}$/, Faker::Address.postcode)
   end
 
   def test_da_dk_building_number
-    assert_match /[\d]{1,3}$/, Faker::Address.building_number
+    assert_match(/[\d]{1,3}$/, Faker::Address.building_number)
   end
 end

--- a/test/test_en_locale.rb
+++ b/test/test_en_locale.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TesetEnLocale < Test::Unit::TestCase
+class TestEnLocale < Test::Unit::TestCase
   def setup
-    Faker::Config.locale = nil
+    Faker::Config.locale = 'en'
   end
 
   def teardown
@@ -17,7 +17,6 @@ class TesetEnLocale < Test::Unit::TestCase
   end
 
   def test_us_zip_codes
-    Faker::Config.locale = 'en-US'
     expected = /\d{5}(\-\d{4})?/
     assert_match(expected, Faker::Address.zip_code)
   end

--- a/test/test_en_us_locale.rb
+++ b/test/test_en_us_locale.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TesetEnUsLocale < Test::Unit::TestCase
+class TestEnUsLocale < Test::Unit::TestCase
   def setup
-    Faker::Config.locale = nil
+    Faker::Config.locale = 'en-US'
   end
 
   def teardown
@@ -10,6 +10,8 @@ class TesetEnUsLocale < Test::Unit::TestCase
   end
 
   def test_us_phone_methods_return_nil_for_nil_locale
+    Faker::Config.locale = nil
+
     assert_nil Faker::PhoneNumber.area_code
     assert_nil Faker::PhoneNumber.exchange_code
   end
@@ -22,8 +24,6 @@ class TesetEnUsLocale < Test::Unit::TestCase
   end
 
   def test_us_phone_methods_with_en_us_locale
-    Faker::Config.locale = 'en-US'
-
     assert Faker::PhoneNumber.area_code.is_a? String
     assert Faker::PhoneNumber.area_code.to_i.is_a? Integer
     assert_equal Faker::PhoneNumber.area_code.length, 3
@@ -34,22 +34,16 @@ class TesetEnUsLocale < Test::Unit::TestCase
   end
 
   def test_validity_of_phone_method_output
-    Faker::Config.locale = 'en-US'
-
     # got the following regex from http://stackoverflow.com/a/123666/1210055 as an expression of the NANP standard.
     us_number_validation_regex = /^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/
     assert_match(us_number_validation_regex, Faker::PhoneNumber.phone_number)
   end
 
   def test_us_invalid_state_raises_exception
-    Faker::Config.locale = 'en-US'
     assert_raise I18n::MissingTranslationData do Faker::Address.zip_code('NA') end
   end
 
   def test_us_zip_codes_match_state
-
-    Faker::Config.locale = 'en-US'
-
     state_abbr = 'AZ'
     expected = /^850\d\d$/
     assert_match(expected, Faker::Address.zip_code(state_abbr))
@@ -74,7 +68,6 @@ class TesetEnUsLocale < Test::Unit::TestCase
     state_abbr = 'VA'
     expected = /^222\d\d$/
     assert_match(expected, Faker::Address.zip_code(state_abbr))
-
   end
 
   def test_valid_id_number

--- a/test/test_es_locale.rb
+++ b/test/test_es_locale.rb
@@ -6,28 +6,28 @@ LoadedEsYaml = ['en', 'es'].inject({}) do |h, locale|
 end
 
 class TestEsLocale < Test::Unit::TestCase
+  def setup
+    Faker::Config.locale = 'es'
+  end
+
   def teardown
     Faker::Config.locale = nil
   end
 
   def test_locale_separate_from_i18n
     I18n.locale = :en
-    Faker::Config.locale = :es
     assert Faker::Address.street_name.match(//)
   end
 
   def test_configured_locale_translation
-    Faker::Config.locale = 'es'
     assert_equal Faker::Base.translate('faker.address.city_prefix').first, LoadedEsYaml['es']['address']['city_prefix'].first
   end
 
   def test_locale_override_when_calling_translate
-    Faker::Config.locale = 'es'
     assert_equal Faker::Base.translate('faker.lorem.words', :locale => :en).first, LoadedEsYaml['en']['lorem']['words'].first
   end
 
   def test_translation_fallback
-    Faker::Config.locale = 'es'
     assert_nil LoadedEsYaml['es']['company']['bs']
     assert_equal Faker::Base.translate('faker.company.bs'), LoadedEsYaml['en']['company']['bs']
   end

--- a/test/test_fi_locale.rb
+++ b/test/test_fi_locale.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TesetEnLocale < Test::Unit::TestCase
+class TestFiLocale < Test::Unit::TestCase
   def setup
     Faker::Config.locale = 'fi-FI'
   end
@@ -19,15 +19,15 @@ class TesetEnLocale < Test::Unit::TestCase
   end
 
   def test_fi_phone_number
-    assert_match /0\d{2}[\-\s]?\d{6}/, Faker::PhoneNumber.cell_phone
-    assert_match /\d{2,3}[\s\-]?\d{5,6}/, Faker::PhoneNumber.phone_number
+    assert_match(/0\d{2}[\-\s]?\d{6}/, Faker::PhoneNumber.cell_phone)
+    assert_match(/\d{2,3}[\s\-]?\d{5,6}/, Faker::PhoneNumber.phone_number)
   end
 
   def test_fi_building_number
-    assert_match /^[\d]{1,3}$/, Faker::Address.building_number
+    assert_match(/^[\d]{1,3}$/, Faker::Address.building_number)
   end
 
   def test_fi_post_code
-    assert_match /^[\d]{5}$/, Faker::Address.postcode
+    assert_match(/^[\d]{5}$/, Faker::Address.postcode)
   end
 end

--- a/test/test_pt_locale.rb
+++ b/test/test_pt_locale.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TestEsLocale < Test::Unit::TestCase
+class TestPtLocale < Test::Unit::TestCase
   def setup
     Faker::Config.locale = "pt"
   end
@@ -10,18 +10,18 @@ class TestEsLocale < Test::Unit::TestCase
   end
 
   def test_pl_phone_number
-    assert_match /^(\+351)?[\(\)\d\s\-]+$/, Faker::PhoneNumber.phone_number
+    assert_match(/^(\+351)?[\(\)\d\s\-]+$/, Faker::PhoneNumber.phone_number)
   end
 
   def test_pl_building_number
-    assert_match /^[\d]{3,5}$/, Faker::Address.building_number
+    assert_match(/^[\d]{3,5}$/, Faker::Address.building_number)
   end
 
   def test_pl_post_code
-    assert_match /^[\d]{4}$/, Faker::Address.postcode
+    assert_match(/^[\d]{4}$/, Faker::Address.postcode)
   end
 
   def test_pl_secondary_address
-    assert_match /^[[:word:]]+[\.]? \d{1,3}$/, Faker::Address.secondary_address
+    assert_match(/^[[:word:]]+[\.]? \d{1,3}$/, Faker::Address.secondary_address)
   end
 end


### PR DESCRIPTION
There were some warnings in test output. Some were regarding regex and
some regarding duplicate setup and teardown methods.

The warnings can be seen in this build:
[https://travis-ci.org/stympy/faker/jobs/118197388](https://travis-ci.org/stympy/faker/jobs/118197388)

The duplicacy was due to incorrect (or rather duplicate class names).
This PR fixes these issues and clears up all warnings from test output.