### PR TITLE
fixed credit_card_types missing single qoutes

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -139,7 +139,7 @@ en:
     business:
       credit_card_numbers: ['1234-2121-1221-1211', '1212-1221-1121-1234', '1211-1221-1234-2201', '1228-1221-1221-1431']
       credit_card_expiry_dates: ['2011-10-12', '2012-11-12', '2015-11-11', '2013-9-12']
-      credit_card_types: ['visa', 'mastercard', 'american_express', 'discover', 'diners_club', 'jcb', 'switch', 'solo', 'dankort', maestro', 'forbrugsforeningen', 'laser']
+      credit_card_types: ['visa', 'mastercard', 'american_express', 'discover', 'diners_club', 'jcb', 'switch', 'solo', 'dankort', 'maestro', 'forbrugsforeningen', 'laser']
 
     color:
       name: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]


### PR DESCRIPTION
`maestro` missed single quote, that broke my tests (on dependant project: https://github.com/datarator/datarator) from time to time