### PR TITLE
Fix pt-BR street_name and postalcodes

### DIFF
--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -3,34 +3,62 @@ pt-BR:
     address:
       city_prefix: [Nova, Velha, Grande, Vila, Município de]
       city_suffix: [do Descoberto, de Nossa Senhora, do Norte, do Sul]
-      country: [ "Afeganistão", "Albânia", "Algéria", "Samoa", "Andorra", "Angola", "Anguilla", "Antigua and Barbada", "Argentina", "Armênia", "Aruba", "Austrália", 
-                 "Áustria", "Alzerbajão", "Bahamas", "Barém", "Bangladesh", "Barbado", "Belgrado", "Bélgica", "Belize", "Benin", "Bermuda", "Bhutan", "Bolívia", 
-                 "Bôsnia", "Botuasuna", "Bouvetoia", "Brasil", "Arquipélago de Chagos", "Ilhas Virgens", "Brunei", "Bulgária", "Burkina Faso", "Burundi", "Cambójia", 
-                 "Camarões", "Canadá", "Cabo Verde", "Ilhas Caiman", "República da África Central", "Chad", "Chile", "China", "Ilhas Natal", "Ilhas Cocos", "Colômbia", 
-                 "Comoros", "Congo", "Ilhas Cook", "Costa Rica", "Costa do Marfim", "Croácia", "Cuba", "Cyprus", "República Tcheca", "Dinamarca", "Djibouti", "Dominica", 
-                 "República Dominicana", "Equador", "Egito", "El Salvador", "Guiné Equatorial", "Eritrea", "Estônia", "Etiópia", "Ilhas Faroe", "Malvinas", "Fiji", 
-                 "Finlândia", "França", "Guiné Francesa", "Polinésia Francesa", "Gabão", "Gâmbia", "Georgia", "Alemanha", "Gana", "Gibraltar", "Grécia", "Groelândia", 
-                 "Granada", "Guadalupe", "Guano", "Guatemala", "Guernsey", "Guiné", "Guiné-Bissau", "Guiana", "Haiti", "Heard Island and McDonald Islands", "Vaticano", 
-                 "Honduras", "Hong Kong", "Hungria", "Iceland", "Índia", "Indonésia", "Irã", "Iraque", "Irlanda", "Ilha de Man", "Israel", "Itália", "Jamaica", "Japão", 
-                 "Jersey", "Jordânia", "Cazaquistão", "Quênia", "Kiribati", "Coreia do Norte", "Coreia do Sul", "Kuwait", "Kyrgyz Republic", "República Democrática de Lao People", 
-                 "Latvia", "Líbano", "Lesotho", "Libéria", "Libyan Arab Jamahiriya", "Liechtenstein", "Lituânia", "Luxemburgo", "Macao", "Macedônia", "Madagascar", "Malawi", 
-                 "Malásia", "Maldives", "Mali", "Malta", "Ilhas Marshall", "Martinica", "Mauritânia", "Mauritius", "Mayotte", "México", "Micronésia", "Moldova", "Mônaco", 
-                 "Mongólia", "Montenegro", "Montserrat", "Marrocos", "Moçambique", "Myanmar", "Namibia", "Nauru", "Nepal", "Antilhas Holandesas", "Holanda", "Nova Caledonia", 
-                 "Nova Zelândia", "Nicarágua", "Nigéria", "Niue", "Ilha Norfolk", "Northern Mariana Islands", "Noruega", "Oman", "Paquistão", "Palau", "Território da Palestina", 
-                 "Panamá", "Nova Guiné Papua", "Paraguai", "Peru", "Filipinas", "Polônia", "Portugal", "Puerto Rico", "Qatar", "Romênia", "Rússia", "Ruanda", "São Bartolomeu", 
-                 "Santa Helena", "Santa Lúcia", "Saint Martin", "Saint Pierre and Miquelon", "Saint Vincent and the Grenadines", "Samoa", "San Marino", "Sao Tomé e Príncipe", 
-                 "Arábia Saudita", "Senegal", "Sérvia", "Seychelles", "Serra Leoa", "Singapura", "Eslováquia", "Eslovênia", "Ilhas Salomão", "Somália", 
-                 "África do Sul", "South Georgia and the South Sandwich Islands", "Spanha", "Sri Lanka", "Sudão", "Suriname", "Svalbard & Jan Mayen Islands", "Swaziland", 
-                 "Suécia", "Suíça", "Síria", "Taiwan", "Tajiquistão", "Tanzânia", "Tailândia", "Timor-Leste", "Togo", "Tokelau", "Tonga", "Trinidá e Tobago", "Tunísia", 
-                 "Turquia", "Turcomenistão", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ucrânia", "Emirados Árabes Unidos", "Reino Unido", "Estados Unidos da América", 
+      country: [ "Afeganistão", "Albânia", "Algéria", "Samoa", "Andorra", "Angola", "Anguilla", "Antigua and Barbada", "Argentina", "Armênia", "Aruba", "Austrália",
+                 "Áustria", "Alzerbajão", "Bahamas", "Barém", "Bangladesh", "Barbado", "Belgrado", "Bélgica", "Belize", "Benin", "Bermuda", "Bhutan", "Bolívia",
+                 "Bôsnia", "Botuasuna", "Bouvetoia", "Brasil", "Arquipélago de Chagos", "Ilhas Virgens", "Brunei", "Bulgária", "Burkina Faso", "Burundi", "Cambójia",
+                 "Camarões", "Canadá", "Cabo Verde", "Ilhas Caiman", "República da África Central", "Chad", "Chile", "China", "Ilhas Natal", "Ilhas Cocos", "Colômbia",
+                 "Comoros", "Congo", "Ilhas Cook", "Costa Rica", "Costa do Marfim", "Croácia", "Cuba", "Cyprus", "República Tcheca", "Dinamarca", "Djibouti", "Dominica",
+                 "República Dominicana", "Equador", "Egito", "El Salvador", "Guiné Equatorial", "Eritrea", "Estônia", "Etiópia", "Ilhas Faroe", "Malvinas", "Fiji",
+                 "Finlândia", "França", "Guiné Francesa", "Polinésia Francesa", "Gabão", "Gâmbia", "Georgia", "Alemanha", "Gana", "Gibraltar", "Grécia", "Groelândia",
+                 "Granada", "Guadalupe", "Guano", "Guatemala", "Guernsey", "Guiné", "Guiné-Bissau", "Guiana", "Haiti", "Heard Island and McDonald Islands", "Vaticano",
+                 "Honduras", "Hong Kong", "Hungria", "Iceland", "Índia", "Indonésia", "Irã", "Iraque", "Irlanda", "Ilha de Man", "Israel", "Itália", "Jamaica", "Japão",
+                 "Jersey", "Jordânia", "Cazaquistão", "Quênia", "Kiribati", "Coreia do Norte", "Coreia do Sul", "Kuwait", "Kyrgyz Republic", "República Democrática de Lao People",
+                 "Latvia", "Líbano", "Lesotho", "Libéria", "Libyan Arab Jamahiriya", "Liechtenstein", "Lituânia", "Luxemburgo", "Macao", "Macedônia", "Madagascar", "Malawi",
+                 "Malásia", "Maldives", "Mali", "Malta", "Ilhas Marshall", "Martinica", "Mauritânia", "Mauritius", "Mayotte", "México", "Micronésia", "Moldova", "Mônaco",
+                 "Mongólia", "Montenegro", "Montserrat", "Marrocos", "Moçambique", "Myanmar", "Namibia", "Nauru", "Nepal", "Antilhas Holandesas", "Holanda", "Nova Caledonia",
+                 "Nova Zelândia", "Nicarágua", "Nigéria", "Niue", "Ilha Norfolk", "Northern Mariana Islands", "Noruega", "Oman", "Paquistão", "Palau", "Território da Palestina",
+                 "Panamá", "Nova Guiné Papua", "Paraguai", "Peru", "Filipinas", "Polônia", "Portugal", "Puerto Rico", "Qatar", "Romênia", "Rússia", "Ruanda", "São Bartolomeu",
+                 "Santa Helena", "Santa Lúcia", "Saint Martin", "Saint Pierre and Miquelon", "Saint Vincent and the Grenadines", "Samoa", "San Marino", "Sao Tomé e Príncipe",
+                 "Arábia Saudita", "Senegal", "Sérvia", "Seychelles", "Serra Leoa", "Singapura", "Eslováquia", "Eslovênia", "Ilhas Salomão", "Somália",
+                 "África do Sul", "South Georgia and the South Sandwich Islands", "Spanha", "Sri Lanka", "Sudão", "Suriname", "Svalbard & Jan Mayen Islands", "Swaziland",
+                 "Suécia", "Suíça", "Síria", "Taiwan", "Tajiquistão", "Tanzânia", "Tailândia", "Timor-Leste", "Togo", "Tokelau", "Tonga", "Trinidá e Tobago", "Tunísia",
+                 "Turquia", "Turcomenistão", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ucrânia", "Emirados Árabes Unidos", "Reino Unido", "Estados Unidos da América",
                  "Estados Unidos das Ilhas Virgens", "Uruguai", "Uzbequistão", "Vanuatu", "Venezuela", "Vietnã", "Wallis and Futuna", "Sahara", "Yemen", "Zâmbia", "Zimbábue"]
       building_number: ["#####", "####", "###", "s/n"]
       street_suffix: ["Rua", "Avenida", "Travessa", "Ponte", "Alameda", "Marginal", "Viela", "Rodovia"]
+      street_name:
+        - "#{street_suffix} #{Name.first_name}"
+        - "#{street_suffix} #{Name.first_name} #{Name.last_name}"
       secondary_address: ["Apto. ###", "Sobrado ##", "Casa #", "Lote ##", "Quadra ##"]
       # Though these are US-specific, they are here (in the default locale) for backwards compatibility
-      postcode: ["#####", "#####-###"]
+      postcode: ["#####-###"]
       state: ["Acre", "Alagoas", "Amapá", "Amazonas", "Bahia", "Ceará", "Distrito Federal", "Espírito Santo", "Goiás", "Maranhão", "Mato Grosso", "Mato Grosso do Sul", "Minas Gerais", "Pará", "Paraíba", "Paraná", "Pernambuco", "Piauí", "Rio de Janeiro", "Rio Grande do Norte", "Rio Grande do Sul", "Rondônia", "Roraima", "Santa Catarina", "São Paulo", "Sergipe", "Tocantins"]
       state_abbr: [AC, AL, AP, AM, BA, CE, DF, ES, GO, MA, MT, MS, PA, PB, PR, PE, PI, RJ, RN, RS, RO, RR, SC, SP]
+      postcode_by_state:
+        SP: '1####-###'
+        RJ: '2####-###'
+        MG: '3####-###'
+        BA: '4####-###'
+        SE: '49###-###'
+        PE: '5####-###'
+        AL: '57###-###'
+        PB: '58###-###'
+        RN: '59###-###'
+        CE: '60###-###'
+        PI: '64###-###'
+        MA: '65###-###'
+        PA: '66###-###'
+        AP: '68###-###'
+        AM: '69###-###'
+        AC: '69###-###'
+        DF: '70###-###'
+        GO: '72###-###'
+        TO: '77###-###'
+        MT: '78###-###'
+        MS: '79###-###'
+        PR: '80###-###'
+        SC: '88###-###'
+        RS: '90###-###'
       default_country: [Brasil]
 
     company:
@@ -39,7 +67,7 @@ pt-BR:
         - "#{Name.last_name} #{suffix}"
         - "#{Name.last_name}-#{Name.last_name}"
         - "#{Name.last_name}, #{Name.last_name} e #{Name.last_name}"
-      
+
     internet:
       free_email: [gmail.com, yahoo.com, hotmail.com, live.com, bol.com.br]
       domain_suffix: [br, com, biz, info, name, net, org]
@@ -50,7 +78,7 @@ pt-BR:
     name:
       first_name: ["Alessandro", "Alessandra", "Alexandre", "Aline", "Antônio", "Breno", "Bruna", "Carlos", "Carla", "Célia", "Cecília", "César", "Danilo", "Dalila", "Deneval", "Eduardo", "Eduarda", "Esther", "Elísio", "Fábio", "Fabrício", "Fabrícia", "Félix", "Felícia", "Feliciano", "Frederico", "Fabiano", "Gustavo", "Guilherme", "Gúbio", "Heitor", "Hélio", "Hugo", "Isabel", "Isabela", "Ígor", "João", "Joana", "Júlio César", "Júlio", "Júlia", "Janaína", "Karla", "Kléber", "Lucas", "Lorena", "Lorraine", "Larissa", "Ladislau", "Marcos", "Meire", "Marcelo", "Marcela", "Margarida", "Mércia", "Márcia", "Marli", "Morgana", "Maria", "Norberto", "Natália", "Nataniel", "Núbia", "Ofélia", "Paulo", "Paula", "Pablo", "Pedro", "Raul", "Rafael", "Rafaela", "Ricardo", "Roberto", "Roberta", "Sílvia", "Sílvia", "Silas", "Suélen", "Sara", "Salvador", "Sirineu", "Talita", "Tertuliano", "Vicente", "Víctor", "Vitória", "Yango", "Yago", "Yuri", "Washington", "Warley"]
       last_name: ["Silva", "Souza", "Carvalho", "Santos", "Reis", "Xavier", "Franco", "Braga", "Macedo", "Batista", "Barros", "Moraes", "Costa", "Pereira", "Carvalho", "Melo", "Saraiva", "Nogueira", "Oliveira", "Martins", "Moreira", "Albuquerque"]
-      prefix: ["Sr.", "Sra.", "Srta.", "Dr."]
+      prefix: ["Sr.", "Sra.", "Srta.", "Dr.", "Dra."]
       suffix: ["Jr.", "Neto", "Filho"]
 
     phone_number:


### PR DESCRIPTION
- Fixes street name (latin languages use 'street, av, rd' as prefix, not suffix)
- Fixes postal codes with states
- Adds formal 'Dra.'

Is there some plans to support sex btw? Another issue with latin languages... hehe..
He is a 'Dr.' She is a 'Dra.'  He is a 'Sr.' She is a 'Sra.'. Everything has sex.