### PR TITLE
Fix Faker::Time methods with dates where DST change occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,15 +430,16 @@ Faker::PhoneNumber.extension #=> "3764"
 Faker::Time.between(DateTime.now - 1, DateTime.now) #=> "2014-09-18 12:30:59 -0700"
 
 # Random date between dates (within specified part of the day)
-# You can install the active_support gem to facilitate time manipulation like 45.minutes + 2.hours
-require "as-duration"
-Faker::Time.between(2.days.ago, Time.now, :all) #=> "2014-09-19 07:03:30 -0700"
-Faker::Time.between(2.days.ago, Time.now, :day) #=> "2014-09-18 16:28:13 -0700"
-Faker::Time.between(2.days.ago, Time.now, :night) #=> "2014-09-20 19:39:38 -0700"
-Faker::Time.between(2.days.ago, Time.now, :morning) #=> "2014-09-19 08:07:52 -0700"
-Faker::Time.between(2.days.ago, Time.now, :afternoon) #=> "2014-09-18 12:10:34 -0700"
-Faker::Time.between(2.days.ago, Time.now, :evening) #=> "2014-09-19 20:21:03 -0700"
-Faker::Time.between(2.days.ago, Time.now, :midnight) #=> "2014-09-20 00:40:14 -0700"
+# You can install the as-duration gem to facilitate time manipulation like 45.minutes + 2.hours
+# (not needed if you already have activesupport, which is included with Rails)
+require 'as-duration'
+Faker::Time.between(2.days.ago, Date.today, :all) #=> "2014-09-19 07:03:30 -0700"
+Faker::Time.between(2.days.ago, Date.today, :day) #=> "2014-09-18 16:28:13 -0700"
+Faker::Time.between(2.days.ago, Date.today, :night) #=> "2014-09-20 19:39:38 -0700"
+Faker::Time.between(2.days.ago, Date.today, :morning) #=> "2014-09-19 08:07:52 -0700"
+Faker::Time.between(2.days.ago, Date.today, :afternoon) #=> "2014-09-18 12:10:34 -0700"
+Faker::Time.between(2.days.ago, Date.today, :evening) #=> "2014-09-19 20:21:03 -0700"
+Faker::Time.between(2.days.ago, Date.today, :midnight) #=> "2014-09-20 00:40:14 -0700"
 
 # Random time in the future (up to maximum of N days)
 Faker::Time.forward(23, :morning) # => "2014-09-26 06:54:47 -0700"

--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -12,41 +12,30 @@ module Faker
 
     class << self
       def between(from, to, period = :all)
-        time_parameters = from.is_a?(::Time) && to.is_a?(::Time)
-
-        if time_parameters
-          random_time = Faker::Base::rand_in_range(from.to_f, to.to_f)
-          random_time = ::Time.at(random_time)
-        else
-          random_time = super(from, to).to_time + random_time(period)
-        end
-
-        random_time
+        date_with_random_time(super(from, to), period)
       end
 
       def forward(days = 365, period = :all)
-        super(days).to_time + random_time(period)
+        date_with_random_time(super(days), period)
       end
 
       def backward(days = 365, period = :all)
-        super(days).to_time + random_time(period)
+        date_with_random_time(super(days), period)
       end
 
       private
 
-      def random_time(period)
-        hours(period) + minutes + seconds
+      def date_with_random_time(date, period)
+        ::Time.local(date.year, date.month, date.day, hours(period), minutes, seconds)
       end
 
       def hours(period)
         raise ArgumentError, 'invalid period' unless TIME_RANGES.has_key? period
-        hour_at_period = TIME_RANGES[period].to_a.sample
-
-        (60 * 60 * hour_at_period)
+        TIME_RANGES[period].to_a.sample
       end
 
       def minutes
-        60 * seconds
+        seconds
       end
 
       def seconds

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -9,8 +9,8 @@ class TestFakerTime < Test::Unit::TestCase
   end
 
   def test_between_with_time_parameters
-    from = Time.local(2014, 12, 28, 06, 0, 0)
-    to   = Time.local(2014, 12, 30, 13, 0, 0)
+    from = Time.at(0)
+    to   = Time.at(2145945600)
 
     100.times do
       random_time = @tester.between(from, to)
@@ -20,8 +20,8 @@ class TestFakerTime < Test::Unit::TestCase
   end
 
   def test_between_with_date_parameters
-    from = Date.parse("2014-12-28")
-    to   = Date.parse("2014-12-30")
+    from = Time.at(0).to_date
+    to   = Time.at(2145945600).to_date
 
     100.times do
       random_time = @tester.between(from, to)
@@ -74,8 +74,8 @@ class TestFakerTime < Test::Unit::TestCase
   end
 
   def test_time_period
-    from = Date.today
-    to   = Date.today + 15
+    from = Time.at(0).to_date
+    to   = Time.at(2145945600).to_date
 
     100.times do
       period          = @time_ranges.keys.to_a.sample
@@ -85,8 +85,8 @@ class TestFakerTime < Test::Unit::TestCase
       random_between  = @tester.between(from, to, period)
       random_forward  = @tester.forward(30, period)
 
-      [random_backward, random_between, random_forward].each do |result|
-        assert period_range.include?(result.hour.to_i), "\"#{result.hour}\" expected to be included in Faker::Time::TIME_RANGES[:#{period}] range"
+      [random_backward, random_between, random_forward].each_with_index do |result, index|
+        assert period_range.include?(result.hour.to_i), "#{[:random_backward, :random_between, :random_forward][index]}: \"#{result}\" expected to be included in Faker::Time::TIME_RANGES[:#{period}] range"
       end
     end
   end


### PR DESCRIPTION
I've refactored `Faker::Time` because it had two problems that I noticed:

1. This fixes #529 which was an intermittent test failure due to Daylight Savings Time. Any time it picked a random date that was when the DST transition occurred, adding seconds to that date would end up adding/removing an extra hour. To work around this, I build a `::Time` object, specifying the exact hour.
2. `Faker::Time.between` with a specified `period`, and `from` & `to` that were `::Time` objects, wasn't providing the intended result, as far as I could tell. It picked a random date & time between the `from` and `to` but made no effort to make sure the hour was contained within the given `period`. The new code is perhaps a simplification - it will return a time within the range of dates given, but if passed a `to` time of 02:00 and a period of `:evening`, then you may get a time outside of your range. It will still be, at the latest, 21:00 on the `to` date, but technically that will be later than the `to` time. Doing this properly with from & to times would be a complicated problem, and since it didn't work to begin with, I decided to implement a version that respects the `period`, at least.

I also beefed up the tests to use truly random dates so that the DST problem surfaces itself more reliably in the future.