### PR TITLE
Added unit tests for de-CH locale

### DIFF
--- a/test/test_de_ch_locale.rb
+++ b/test/test_de_ch_locale.rb
@@ -1,0 +1,19 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestDeAtLocale < Test::Unit::TestCase
+  def setup
+    Faker::Config.locale = 'de-AT'
+  end
+
+  def teardown
+    Faker::Config.locale = nil
+  end
+
+  def test_de_ch_methods
+    assert Faker::Address.country_code.is_a? String
+    assert Faker::Address.default_country.is_a? String
+    assert Faker::Company.suffix.is_a? String
+    assert Faker::Company.name.is_a? String
+    assert Faker::Internet.domain_suffix.is_a? String
+  end
+end


### PR DESCRIPTION
Hello. 

Looks like ```de-CH``` locale was missing unit tests as well. These are now added. This improves code coverage and adds additional safeguard for future modifications. I did execute ```bundle exec rake``` before committing and all tests passed.

Thank you.