### PR TITLE
Fix invalid en-GB postcodes

### DIFF
--- a/lib/locales/en-GB.yml
+++ b/lib/locales/en-GB.yml
@@ -1,7 +1,7 @@
 en-GB:
   faker:
     address:
-      postcode: /[A-PR-UWYZ][A-HK-Y]?[0-9][ABEHMNPRVWXY0-9]? [0-9][ABD-HJLN-UW-Z]{2}/
+      postcode: /[A-PR-UWYZ][A-HK-Y]?[0-9][ABEHMNPRVWXY0-9]? [0-9][ABD-HJLNP-UW-Z]{2}/
       county: [Avon, Bedfordshire, Berkshire, Borders, Buckinghamshire, Cambridgeshire, Central, Cheshire, Cleveland, Clwyd, Cornwall, County Antrim, County Armagh, County Down, County Fermanagh, County Londonderry, County Tyrone, Cumbria, Derbyshire, Devon, Dorset, Dumfries and Galloway, Durham, Dyfed, East Sussex, Essex, Fife, Gloucestershire, Grampian, Greater Manchester, Gwent, Gwynedd County, Hampshire, Herefordshire, Hertfordshire, Highlands and Islands, Humberside, Isle of Wight, Kent, Lancashire, Leicestershire, Lincolnshire, Lothian, Merseyside, Mid Glamorgan, Norfolk, North Yorkshire, Northamptonshire, Northumberland, Nottinghamshire, Oxfordshire, Powys, Rutland, Shropshire, Somerset, South Glamorgan, South Yorkshire, Staffordshire, Strathclyde, Suffolk, Surrey, Tayside, Tyne and Wear, Warwickshire, West Glamorgan, West Midlands, West Sussex, West Yorkshire, Wiltshire, Worcestershire]
       uk_country: [England, Scotland, Wales, Northern Ireland]
       default_country: [England, Scotland, Wales, Northern Ireland]

--- a/test/test_en_gb_locale.rb
+++ b/test/test_en_gb_locale.rb
@@ -26,4 +26,15 @@ class TestEnGbLocale < Test::Unit::TestCase
     mobile = Faker::PhoneNumber.cell_phone.gsub(/\D/,'')
     assert_equal '0', mobile[0]
   end
+
+  def test_gb_postcode_has_outcode_and_incode
+    postcode = Faker::Address.postcode
+    assert_equal 2, postcode.split(' ').length
+  end
+
+  def test_gb_postcode_incode_is_valid
+    #The letters C I K M O V are not used in the second part of the Postcode.
+    incode = Faker::Address.postcode.split(' ')[1]
+    assert_match(/\d[ABDEFGHJLNPQRSTUWXYZ]{2}/, incode)
+  end
 end


### PR DESCRIPTION
The pattern for UK postcodes currently allows the letter 'O' in either of the last 2 positions.

According to the fine print for the postcode format - see bottom of page 17 [here](http://www.royalmail.com/sites/default/files/docs/pdf/programmers_guide_edition_7_v5.pdf) - UK postcodes can't have any of CIKMOV in the last two characters. 

The test smells a bit - let me know if you want it changed