### PR TITLE
[29 Feb bugfix] Call birthday for leap year

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development, :test do
   gem "test-unit"
   gem "rake"
   gem "minitest"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     minitest (5.8.3)
     rake (10.1.0)
     test-unit (2.5.5)
+    timecop (0.8.1)
 
 PLATFORMS
   ruby
@@ -20,3 +21,7 @@ DEPENDENCIES
   minitest
   rake
   test-unit
+  timecop
+
+BUNDLED WITH
+   1.11.2

--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -32,13 +32,41 @@ module Faker
 
       def birthday(min_age = 18, max_age = 65)
         t = ::Date.today
-        from =  ::Date.new(t.year - min_age, t.month, t.day)
-        to   =  ::Date.new(t.year - max_age, t.month, t.day)
+        top_bound, bottom_bound = prepare_bounds(t, min_age, max_age)
+        years = handled_leap_years(top_bound, bottom_bound)
+
+        from =  ::Date.new(years[0], t.month, t.day)
+        to   =  ::Date.new(years[1], t.month, t.day)
 
         between(from, to).to_date
       end
 
       private
+
+      def prepare_bounds(t, min_age, max_age)
+        [t.year - min_age, t.year - max_age]
+      end
+
+      def handled_leap_years(top_bound, bottom_bound)
+        if (top_bound % 4) != 0 || (bottom_bound % 4) != 0
+          [
+            customized_bound(top_bound),
+            customized_bound(bottom_bound, true)
+          ]
+        else
+          [top_bound, bottom_bound]
+        end
+      end
+
+      def customized_bound(bound, increase = false)
+        if (bound % 4) != 0
+          bound = bound + 1 if increase
+          bound = bound - 1 unless increase
+          customized_bound(bound, increase)
+        else
+          bound
+        end
+      end
 
       def get_date_object(date)
         date = ::Date.parse(date) if date.is_a?(String)

--- a/test/test_faker_birthday_in_leap_year.rb
+++ b/test/test_faker_birthday_in_leap_year.rb
@@ -1,0 +1,29 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestFakerBirthdayInLeapYear < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Date
+    @today = Date.parse("2016-02-29")
+    @min = 18
+    @max = 65
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  def test_birthday_in_leap_year
+    Timecop.freeze(@today)
+    assert_nothing_raised ArgumentError do
+      @tester.birthday
+    end
+
+    assert_raise ArgumentError do
+       ::Date.new(@today.year - @min, @today.month, @today.day)
+    end
+
+    assert_raise ArgumentError do
+       ::Date.new(@today.year - @max, @today.month, @today.day)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require 'rubygems'
+require 'timecop'
 require 'yaml'
 YAML::ENGINE.yamler = 'syck' if defined? YAML::ENGINE
 require File.expand_path(File.dirname(__FILE__) + '/../lib/faker')


### PR DESCRIPTION
I've fixed generate birthday for leap years. 
if run ``Faker::Date.birthday`` it will call error ``ArgumentError: invalid date``
Also i've added the test for fix with using timecop. Timecop gem allows freeze time for some moment.