### PR TITLE
Changed quotes in app.rb

### DIFF
--- a/lib/faker/app.rb
+++ b/lib/faker/app.rb
@@ -7,7 +7,7 @@ module Faker
       end
 
       def version
-        if parse('app.version') == ""
+        if parse('app.version') == ''
           numerify(fetch('app.version'))
         else
           parse('app.version')


### PR DESCRIPTION
Hello.

Just a minor fix today.

Since there is no need for string interpolation or special symbols, I replaced double-quotes in ```lib/faker/app.rb``` with single quotes. 

```bundle exec rake``` ran, all green.

Thank you.