### PR TITLE
Convert to keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ development.
 
 * While Faker generates data at random, returned values are not guaranteed to be unique.
 * This is the `master` branch of Faker and may contain changes that are not yet released.
-  Please refer the README of your version for the available methods.
+  Please refer to the README of your version for the available methods.
   List of all versions is [available here](https://github.com/stympy/faker/releases).
 
 Contents
@@ -178,10 +178,10 @@ Faker::Color.hsla_color #=> [154.77, 232.36, 58.9, 0.26170574657729073]
 
 Faker::Commerce.color #=> "lavender"
 
-# Optional arguments max=3, fixed_amount=false
+# Optional arguments max: 3, fixed_amount: false
 Faker::Commerce.department #=> "Grocery, Health & Beauty"
-Faker::Commerce.department(5) #=> "Grocery, Books, Health & Beauty"
-Faker::Commerce.department(2, true) #=> "Books & Tools"
+Faker::Commerce.department(max: 5) #=> "Grocery, Books, Health & Beauty"
+Faker::Commerce.department(max: 2, fixed_amount: true) #=> "Books & Tools"
 
 Faker::Commerce.product_name #=> "Practical Granite Shirt"
 
@@ -228,54 +228,54 @@ Faker::Company.profession #=> "firefighter"
 
 ```ruby
 # Random date between dates
-Faker::Date.between(2.days.ago, Date.today) #=> "Wed, 24 Sep 2014"
+Faker::Date.between(from: 2.days.ago, to: Date.today) #=> "Wed, 24 Sep 2014"
 
 # Random date between dates except for certain date
-Faker::Date.between_except(1.year.ago, 1.year.from_now, Date.today) #=> "Wed, 24 Sep 2014"
+Faker::Date.between_except(from: 1.year.ago, to: 1.year.from_now, except: Date.today) #=> "Wed, 24 Sep 2014"
 
 # Random date in the future (up to maximum of N days)
-Faker::Date.forward(23) # => "Fri, 03 Oct 2014"
+Faker::Date.forward(days: 23) # => "Fri, 03 Oct 2014"
 
 # Random date in the past (up to maximum of N days)
-Faker::Date.backward(14) #=> "Fri, 19 Sep 2014"
+Faker::Date.backward(days: 14) #=> "Fri, 19 Sep 2014"
 ```
 
 ###Faker::Internet
 ---------------
 
 ```ruby
-# Optional argument name=nil
+# Optional argument name: nil
 Faker::Internet.email #=> "eliza@mann.net"
 
-Faker::Internet.email('Nancy') #=> "nancy@terry.biz"
+Faker::Internet.email(name: 'Nancy') #=> "nancy@terry.biz"
 
-# Optional argument name=nil
+# Optional argument name: nil
 Faker::Internet.free_email #=> "freddy@gmail.com"
 
-Faker::Internet.free_email('Nancy') #=> "nancy@yahoo.com"
+Faker::Internet.free_email(name: 'Nancy') #=> "nancy@yahoo.com"
 
-# Optional argument name=nil
+# Optional argument name: nil
 Faker::Internet.safe_email #=> "christelle@example.org"
 
-Faker::Internet.safe_email('Nancy') #=> "nancy@example.net"
+Faker::Internet.safe_email(name: 'Nancy') #=> "nancy@example.net"
 
-# Optional arguments specifier=nil, separators=%w(. _)
+# Optional arguments specifier: nil, separators: %w(. _)
 Faker::Internet.user_name #=> "alexie"
 
-Faker::Internet.user_name('Nancy') #=> "nancy"
+Faker::Internet.user_name(specifier: 'Nancy') #=> "nancy"
 
-Faker::Internet.user_name('Nancy Johnson', %w(. _ -)) #=> "johnson-nancy"
+Faker::Internet.user_name(specifier: 'Nancy Johnson', separators: %w(. _ -)) #=> "johnson-nancy"
 
-# Optional arguments: min_length=8, max_length=16
+# Optional arguments: min_length: 8, max_length: 16, mix_case: true, special_chars: false
 Faker::Internet.password #=> "vg5msvy1uerg7"
 
-Faker::Internet.password(8) #=> "yfgjik0hgzdqs0"
+Faker::Internet.password(min_length: 8) #=> "yfgjik0hgzdqs0"
 
-Faker::Internet.password(10, 20) #=> "eoc9shwd1hwq4vbgfw"
+Faker::Internet.password(min_length: 10, max_length: 20) #=> "eoc9shwd1hwq4vbgfw"
 
-Faker::Internet.password(10, 20, true) #=> "3k5qS15aNmG"
+Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true) #=> "3k5qS15aNmG"
 
-Faker::Internet.password(10, 20, true, true) #=> "*%NkOnJsH4"
+Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_chars: true) #=> "*%NkOnJsH4"
 
 Faker::Internet.domain_name #=> "effertz.info"
 
@@ -299,19 +299,19 @@ Faker::Internet.ip_v6_address #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df"
 
 Faker::Internet.ip_v6_cidr #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df/78"
 
-# Optional argument prefix=''
+# Optional argument prefix: ''
 Faker::Internet.mac_address #=> "e6:0d:00:11:ed:4f"
-Faker::Internet.mac_address('55:44:33') #=> "55:44:33:02:1d:9b"
+Faker::Internet.mac_address(prefix: '55:44:33') #=> "55:44:33:02:1d:9b"
 
-# Optional arguments: host=domain_name, path="/#{user_name}"
+# Optional arguments: host: domain_name, path: "/#{user_name}"
 Faker::Internet.url #=> "http://thiel.com/chauncey_simonis"
-Faker::Internet.url('example.com') #=> "http://example.com/clotilde.swift"
-Faker::Internet.url('example.com', '/foobar.html') #=> "http://example.com/foobar.html"
+Faker::Internet.url(host: 'example.com') #=> "http://example.com/clotilde.swift"
+Faker::Internet.url(host: 'example.com', path: '/foobar.html') #=> "http://example.com/foobar.html"
 
-# Optional arguments: words=nil, glue=nil
+# Optional arguments: words: nil, glue: nil
 Faker::Internet.slug #=> "pariatur_laudantium"
-Faker::Internet.slug('foo bar') #=> "foo.bar"
-Faker::Internet.slug('foo bar', '-') #=> "foo-bar"
+Faker::Internet.slug(words: 'foo bar') #=> "foo.bar"
+Faker::Internet.slug(words: 'foo bar', glue: '-') #=> "foo-bar"
 
 
 ```
@@ -321,11 +321,11 @@ Faker::Internet.slug('foo bar', '-') #=> "foo-bar"
 ```ruby
 Faker::File.extension #=> "mp3"
 Faker::File.mime_type #=> "application/pdf"
-# Optional arguments: dir, name, extension, directory_separator
-Faker::File.file_name('path/to') #=> "path/to/something_random.jpg"
-Faker::File.file_name('foo/bar', 'baz') #=> "foo/bar/baz.zip"
-Faker::File.file_name('foo/bar', 'baz', 'doc') #=> "foo/bar/baz.doc"
-Faker::File.file_name('foo/bar', 'baz', 'mp3', '\') #=> "foo\bar\baz.mp3"
+# Optional arguments: dir:, name:, extension:, directory_separator:
+Faker::File.file_name(dir: 'path/to') #=> "path/to/something_random.jpg"
+Faker::File.file_name(dir: 'foo/bar', name: 'baz') #=> "foo/bar/baz.zip"
+Faker::File.file_name(dir: 'foo/bar', name: 'baz', extension: 'doc') #=> "foo/bar/baz.doc"
+Faker::File.file_name(dir: 'foo/bar', name: 'baz', extension: 'mp3', directory_separator: '_') #=> "foo_bar_baz.mp3"
 ```
 
 ###Faker::Lorem
@@ -335,38 +335,38 @@ Faker::File.file_name('foo/bar', 'baz', 'mp3', '\') #=> "foo\bar\baz.mp3"
 
 Faker::Lorem.word #=> "repellendus"
 
-# Optional arguments: num=3, supplemental=false (words from a supplementary list of Lorem-like words)
+# Optional arguments: count: 3, supplemental: false (words from a supplementary list of Lorem-like words)
 Faker::Lorem.words #=> ["dolores", "adipisci", "nesciunt"]
-Faker::Lorem.words(4) #=> ["culpa", "recusandae", "aut", "omnis"]
-Faker::Lorem.words(4, true) #=> ["colloco", "qui", "vergo", "deporto"]
+Faker::Lorem.words(count: 4) #=> ["culpa", "recusandae", "aut", "omnis"]
+Faker::Lorem.words(count: 4, supplemental: true) #=> ["colloco", "qui", "vergo", "deporto"]
 
 # Optional arguments: char_count=255
 Faker::Lorem.characters #=> "uw1ep04lhs0c4d931n1jmrspprf5wrj85fefue0y7y6m56b6omquh7br7dhqijwlawejpl765nb1716idmp3xnfo85v349pzy2o9rir23y2qhflwr71c1585fnynguiphkjm8p0vktwitcsm16lny7jzp9t4drwav3qmhz4yjq4k04x14gl6p148hulyqioo72tf8nwrxxcclfypz2lc58lsibgfe5w5p0xv95peafjjmm2frkhdc6duoky0aha"
 Faker::Lorem.characters(10) #=> "ang9cbhoa8"
 
-# Optional arguments: word_count=4, supplemental=false, random_words_to_add=6
+# Optional arguments: word_count: 4, supplemental: false, random_words_to_add: 6
 Faker::Lorem.sentence #=> "Dolore illum animi et neque accusantium."
-Faker::Lorem.sentence(3) #=> "Commodi qui minus deserunt sed vero quia."
-Faker::Lorem.sentence(3, true) #=> "Inflammatio denego necessitatibus caelestis autus illum."
-Faker::Lorem.sentence(3, false, 4) #=> "Aut voluptatem illum fugit ut sit."
-Faker::Lorem.sentence(3, true, 4) #=> "Accusantium tantillus dolorem timor."
+Faker::Lorem.sentence(word_count: 3) #=> "Commodi qui minus deserunt sed vero quia."
+Faker::Lorem.sentence(word_count: 3, supplemental: true) #=> "Inflammatio denego necessitatibus caelestis autus illum."
+Faker::Lorem.sentence(word_count: 3, supplemental: false, random_words_to_add: 4) #=> "Aut voluptatem illum fugit ut sit."
+Faker::Lorem.sentence(word_count: 3, supplemental: true, random_words_to_add: 4) #=> "Accusantium tantillus dolorem timor."
 
-# Optional arguments: sentence_count=3, supplemental=false
+# Optional arguments: count: 3, supplemental: false
 Faker::Lorem.sentences #=> ["Vero earum commodi soluta.", "Quaerat fuga cumque et vero eveniet omnis ut.", "Cumque sit dolor ut est consequuntur."]
-Faker::Lorem.sentences(1) #=> ["Ut perspiciatis explicabo possimus doloribus enim quia."]
-Faker::Lorem.sentences(1, true) #=> ["Quis capillus curo ager veritatis voro et ipsum."]
+Faker::Lorem.sentences(count: 1) #=> ["Ut perspiciatis explicabo possimus doloribus enim quia."]
+Faker::Lorem.sentences(count: 1, supplemental: true) #=> ["Quis capillus curo ager veritatis voro et ipsum."]
 
-# Optional arguments: sentence_count=3, supplemental=false, random_sentences_to_add=3
+# Optional arguments: sentence_count: 3, supplemental: false, random_sentences_to_add: 3
 Faker::Lorem.paragraph #=> "Neque dicta enim quasi. Qui corrupti est quisquam. Facere animi quod aut. Qui nulla consequuntur consectetur sapiente."
-Faker::Lorem.paragraph(2) #=> "Illo qui voluptas. Id sit quaerat enim aut cupiditate voluptates dolorum. Porro necessitatibus numquam dolor quia earum."
-Faker::Lorem.paragraph(2, true) #=> "Cedo vero adipisci. Theatrum crustulum coaegresco tonsor crastinus stabilis. Aliqua crur consequatur amor una tolero sum."
-Faker::Lorem.paragraph(2, false, 4) #=> "Neque aut et nemo aut incidunt voluptates. Dolore cum est sint est. Vitae assumenda porro odio dolores fugiat. Est voluptatum quia rerum."
-Faker::Lorem.paragraph(2, true, 4) #=> "Vomito unde uxor annus. Et patior utilis sursum."
+Faker::Lorem.paragraph(sentence_count: 2) #=> "Illo qui voluptas. Id sit quaerat enim aut cupiditate voluptates dolorum. Porro necessitatibus numquam dolor quia earum."
+Faker::Lorem.paragraph(sentence_count: 2, supplemental: true) #=> "Cedo vero adipisci. Theatrum crustulum coaegresco tonsor crastinus stabilis. Aliqua crur consequatur amor una tolero sum."
+Faker::Lorem.paragraph(sentence_count: 2, supplemental: false, random_sentences_to_add: 4) #=> "Neque aut et nemo aut incidunt voluptates. Dolore cum est sint est. Vitae assumenda porro odio dolores fugiat. Est voluptatum quia rerum."
+Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) #=> "Vomito unde uxor annus. Et patior utilis sursum."
 
-# Optional arguments: paragraph_count=3, supplemental=false
+# Optional arguments: count: 3, supplemental: false
 Faker::Lorem.paragraphs #=> ["Dolores quis quia ad quo voluptates. Maxime delectus totam numquam. Necessitatibus vel atque qui dolore.", "Id neque nemo. Dolores iusto facere est ad. Accusamus ipsa dolor ut.", "Et officiis ut hic. Sunt asperiores minus distinctio debitis ipsa dolor. Minima eos deleniti."]
-Faker::Lorem.paragraphs(1) #=> ["Labore voluptas sequi. Ratione nulla eaque quia molestiae fugit. At quam laboriosam aut ut dignissimos."]
-Faker::Lorem.paragraphs(1, true) #=> ["Depulso animi cunctatio amicitia adficio. Vester viduo qui despirmatio voluptas. Validus laudantium adopto ut agnitio venustas. Aer arcus odio esse."]
+Faker::Lorem.paragraphs(count: 1) #=> ["Labore voluptas sequi. Ratione nulla eaque quia molestiae fugit. At quam laboriosam aut ut dignissimos."]
+Faker::Lorem.paragraphs(count: 1, supplemental: true) #=> ["Depulso animi cunctatio amicitia adficio. Vester viduo qui despirmatio voluptas. Validus laudantium adopto ut agnitio venustas. Aer arcus odio esse."]
 
 ```
 
@@ -395,18 +395,18 @@ Faker::Name.title            #=> "Legacy Creative Director"
 ----------------
 
 ```ruby
-
+# Optional arguments: slug: nil, size: '300x300', format: 'png', set: 'set1', bgset: nil
 Faker::Avatar.image #=> "https://robohash.org/sitsequiquia.png?size=300x300"
 
-Faker::Avatar.image("my-own-slug") #=> "https://robohash.org/my-own-slug.png?size=300x300"
+Faker::Avatar.image(slug: "my-own-slug") #=> "https://robohash.org/my-own-slug.png?size=300x300"
 
-Faker::Avatar.image("my-own-slug", "50x50") #=> "https://robohash.org/my-own-slug.png?size=50x50"
+Faker::Avatar.image(slug: "my-own-slug", size: "50x50") #=> "https://robohash.org/my-own-slug.png?size=50x50"
 
-Faker::Avatar.image("my-own-slug", "50x50", "jpg") #=> "https://robohash.org/my-own-slug.jpg?size=50x50"
+Faker::Avatar.image(slug: "my-own-slug", size: "50x50", format: "jpg") #=> "https://robohash.org/my-own-slug.jpg?size=50x50"
 
-Faker::Avatar.image("my-own-slug", "50x50", "bmp") #=> "https://robohash.org/my-own-slug.bmp?size=50x50"
+Faker::Avatar.image(slug: "my-own-slug", size: "50x50", format: "bmp") #=> "https://robohash.org/my-own-slug.bmp?size=50x50"
 
-Faker::Avatar.image("my-own-slug", "50x50", "bmp", "set1", "bg1") #=> "https://robohash.org/my-own-slug.bmp?size=50x50&set=set1&bgset=bg1"
+Faker::Avatar.image(slug: "my-own-slug", size: "50x50", format: "bmp", set: "set1", bgset: "bg1") #=> "https://robohash.org/my-own-slug.bmp?size=50x50&set=set1&bgset=bg1"
 ```
 
 ###Faker::Number
@@ -414,21 +414,25 @@ Faker::Avatar.image("my-own-slug", "50x50", "bmp", "set1", "bg1") #=> "https://r
 
 ```ruby
 
+# Required parameter: digits:
+Faker::Number.number(digits: 10) #=> "1968353479"
+
+# Required parameter: whole_digits:
+# Optional parameter: decimal_digits: 2
+Faker::Number.decimal(whole_digits: 2) #=> "11.88"
+
+Faker::Number.decimal(whole_digits: 2, decimal_digits: 3) #=> "18.843"
+
 # Required parameter: digits
-Faker::Number.number(10) #=> "1968353479"
+Faker::Number.hexadecimal(digits: 3) #=> "e74"
 
-# Required parameter: l_digits
-Faker::Number.decimal(2) #=> "11.88"
+# Optional parameters: from: 1.00, to: 5000.00
+Faker::Number.between(from: 1, to: 10) #=> 7
 
-Faker::Number.decimal(2, 3) #=> "18.843"
-
-# Required parameter: digits
-Faker::Number.hexadecimal(3) #=> "e74"
-
-Faker::Number.between(1, 10) #=> 7
-
+# Optional parameters: from: 1.00, to: 5000.00
 Faker::Number.positive #=> 235.59238499107653
 
+# Optional parameters: from: -5000.00, to: -1.00
 Faker::Number.negative #=> -4480.042585669558
 
 Faker::Number.digit #=> "1"
@@ -440,10 +444,10 @@ Faker::Number.digit #=> "1"
 
 ```ruby
 
-# Optional parameter: true_ratio=0.5
+# Optional parameter: true_ratio: 0.5
 Faker::Boolean.boolean #=> true
 
-Faker::Boolean.boolean(0.2) #=> false
+Faker::Boolean.boolean(true_ratio: 0.2) #=> false
 
 ```
 
@@ -480,10 +484,10 @@ Faker::PhoneNumber.area_code #=> "201"
 # US only
 Faker::PhoneNumber.exchange_code #=> "208"
 
-# Optional parameter: length=4
+# Optional parameter: length: 4
 Faker::PhoneNumber.subscriber_number #=> "3873"
 
-Faker::PhoneNumber.subscriber_number(2) #=> "39"
+Faker::PhoneNumber.subscriber_number(length: 2) #=> "39"
 
 Faker::PhoneNumber.extension #=> "3764"
 
@@ -493,26 +497,31 @@ Faker::PhoneNumber.extension #=> "3764"
 ---------------------
 
 ```ruby
+
+# Required parameters: from:, to:
+# Optional parameter: period: :all
 # Random date between dates
-Faker::Time.between(DateTime.now - 1, DateTime.now) #=> "2014-09-18 12:30:59 -0700"
+Faker::Time.between(from: DateTime.now - 1, to: DateTime.now) #=> "2014-09-18 12:30:59 -0700"
 
 # Random date between dates (within specified part of the day)
 # You can install the as-duration gem to facilitate time manipulation like 45.minutes + 2.hours
 # (not needed if you already have activesupport, which is included with Rails)
 require 'as-duration'
-Faker::Time.between(2.days.ago, Date.today, :all) #=> "2014-09-19 07:03:30 -0700"
-Faker::Time.between(2.days.ago, Date.today, :day) #=> "2014-09-18 16:28:13 -0700"
-Faker::Time.between(2.days.ago, Date.today, :night) #=> "2014-09-20 19:39:38 -0700"
-Faker::Time.between(2.days.ago, Date.today, :morning) #=> "2014-09-19 08:07:52 -0700"
-Faker::Time.between(2.days.ago, Date.today, :afternoon) #=> "2014-09-18 12:10:34 -0700"
-Faker::Time.between(2.days.ago, Date.today, :evening) #=> "2014-09-19 20:21:03 -0700"
-Faker::Time.between(2.days.ago, Date.today, :midnight) #=> "2014-09-20 00:40:14 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :all) #=> "2014-09-19 07:03:30 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :day) #=> "2014-09-18 16:28:13 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :night) #=> "2014-09-20 19:39:38 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :morning) #=> "2014-09-19 08:07:52 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :afternoon) #=> "2014-09-18 12:10:34 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :evening) #=> "2014-09-19 20:21:03 -0700"
+Faker::Time.between(from: 2.days.ago, to: Date.today, period: :midnight) #=> "2014-09-20 00:40:14 -0700"
 
+# Optional parameters: days: 365, period: :all
 # Random time in the future (up to maximum of N days)
-Faker::Time.forward(23, :morning) # => "2014-09-26 06:54:47 -0700"
+Faker::Time.forward(days: 23, period: :morning) # => "2014-09-26 06:54:47 -0700"
 
+# Optional parameters: days: 365, period: :all
 # Random time in the past (up to maximum of N days)
-Faker::Time.backward(14, :evening) #=> "2014-09-17 19:56:33 -0700"
+Faker::Time.backward(days: 14, period: :evening) #=> "2014-09-17 19:56:33 -0700"
 ```
 
 ###Faker::Hacker
@@ -653,17 +662,18 @@ Faker::University.name #=> "South Texas College"
 
 ```ruby
 
+# Optional parameters: size: '300x300', format: 'png', background_color: '000', text_color: nil, text: nil
 Faker::Placeholdit.image #=> "http://placehold.it/300x300.png/000"
 
-Faker::Placeholdit.image("50x50") #=> "http://placehold.it/50x50.png/000"
+Faker::Placeholdit.image(size: "50x50") #=> "http://placehold.it/50x50.png/000"
 
-Faker::Placeholdit.image("50x50", 'jpg') #=> "http://placehold.it/50x50.jpg/000"
+Faker::Placeholdit.image(size: "50x50", format: 'jpg') #=> "http://placehold.it/50x50.jpg/000"
 
-Faker::Placeholdit.image("50x50", 'gif', 'ffffff') #=> "http://placehold.it/50x50.gif/ffffff"
+Faker::Placeholdit.image(size: "50x50", format: 'gif', background_color: 'ffffff') #=> "http://placehold.it/50x50.gif/ffffff"
 
-Faker::Placeholdit.image("50x50", 'jpeg', 'ffffff', '000') #=> "http://placehold.it/50x50.jpeg/ffffff/000"
+Faker::Placeholdit.image(size: "50x50", format: 'jpeg', background_color: 'ffffff', text_color: '000') #=> "http://placehold.it/50x50.jpeg/ffffff/000"
 
-Faker::Placeholdit.image("50x50", 'jpg', 'ffffff', '000', 'Some Custom Text') #=> "http://placehold.it/50x50.jpg/ffffff/000?text='Some Custom Text'"
+Faker::Placeholdit.image(size: "50x50", format: 'jpg', background_color: 'ffffff', text_color: '000', text: 'Some Custom Text') #=> "http://placehold.it/50x50.jpg/ffffff/000?text='Some Custom Text'"
 
 ```
 
@@ -675,35 +685,35 @@ Adapted from [Hipster Ipsum](http://hipsum.co/)
 
 Faker::Hipster.word #=> "irony"
 
-# Optional arguments: num=3, supplemental=false, spaces_allowed = false
+# Optional arguments: count: 3, supplemental: false, spaces_allowed: false
 Faker::Hipster.words #=> ["pug", "pitchfork", "chia"]
-Faker::Hipster.words(4) #=> ["ugh", "cardigan", "poutine", "stumptown"]
-Faker::Hipster.words(4, true) #=> ["iste", "seitan", "normcore", "provident"]
-Faker::Hipster.words(4, true, true) #=> ["qui", "magni", "craft beer", "est"]
+Faker::Hipster.words(count: 4) #=> ["ugh", "cardigan", "poutine", "stumptown"]
+Faker::Hipster.words(count: 4, supplemental: true) #=> ["iste", "seitan", "normcore", "provident"]
+Faker::Hipster.words(count: 4, supplemental: true, spaces_allowed: true) #=> ["qui", "magni", "craft beer", "est"]
 
-# Optional arguments: word_count=4, supplemental=false, random_words_to_add=6
+# Optional arguments: word_count: 4, supplemental: false, random_words_to_add: 6
 Faker::Hipster.sentence #=> "Park iphone leggings put a bird on it."
-Faker::Hipster.sentence(3) #=> "Pour-over swag godard."
-Faker::Hipster.sentence(3, true) #=> "Beard laboriosam sequi celiac."
-Faker::Hipster.sentence(3, false, 4) #=> "Bitters retro mustache aesthetic biodiesel 8-bit."
-Faker::Hipster.sentence(3, true, 4) #=> "Occaecati deleniti messenger bag meh crucifix autem."
+Faker::Hipster.sentence(word_count: 3) #=> "Pour-over swag godard."
+Faker::Hipster.sentence(word_count: 3, supplemental: true) #=> "Beard laboriosam sequi celiac."
+Faker::Hipster.sentence(word_count: 3, supplemental: false, random_words_to_add: 4) #=> "Bitters retro mustache aesthetic biodiesel 8-bit."
+Faker::Hipster.sentence(word_count: 3, supplemental: true, random_words_to_add: 4) #=> "Occaecati deleniti messenger bag meh crucifix autem."
 
-# Optional arguments: sentence_count=3, supplemental=false
+# Optional arguments: count: 3, supplemental: false
 Faker::Hipster.sentences #=> ["Godard pitchfork vinegar chillwave everyday 90's whatever.", "Pour-over artisan distillery street waistcoat.", "Salvia yr leggings franzen blue bottle."]
-Faker::Hipster.sentences(1) #=> ["Before they sold out pinterest venmo umami try-hard ugh hoodie artisan."]
-Faker::Hipster.sentences(1, true) #=> ["Et sustainable optio aesthetic et."]
+Faker::Hipster.sentences(count: 1) #=> ["Before they sold out pinterest venmo umami try-hard ugh hoodie artisan."]
+Faker::Hipster.sentences(count: 1, supplemental: true) #=> ["Et sustainable optio aesthetic et."]
 
-# Optional arguments: sentence_count=3, supplemental=false, random_sentences_to_add=3
+# Optional arguments: sentence_count: 3, supplemental: false, random_sentences_to_add: 3
 Faker::Hipster.paragraph #=> "Migas fingerstache pbr&b tofu. Polaroid distillery typewriter echo tofu actually. Slow-carb fanny pack pickled direct trade scenester mlkshk plaid. Banjo venmo chambray cold-pressed typewriter. Fap skateboard intelligentsia."
-Faker::Hipster.paragraph(2) #=> "Yolo tilde farm-to-table hashtag. Lomo kitsch disrupt forage +1."
-Faker::Hipster.paragraph(2, true) #=> "Typewriter iste ut viral kombucha voluptatem. Sint voluptates saepe. Direct trade irony chia excepturi yuccie. Biodiesel esse listicle et quam suscipit."
-Faker::Hipster.paragraph(2, false, 4) #=> "Selvage vhs chartreuse narwhal vinegar. Authentic vinyl truffaut carry vhs pop-up. Hammock everyday iphone locavore thundercats bitters vegan goth. Fashion axe banh mi shoreditch whatever artisan."
-Faker::Hipster.paragraph(2, true, 4) #=> "Deep v gluten-free unde waistcoat aperiam migas voluptas dolorum. Aut drinking illo sustainable sapiente. Direct trade fanny pack kale chips ennui semiotics."
+Faker::Hipster.paragraph(sentence_count: 2) #=> "Yolo tilde farm-to-table hashtag. Lomo kitsch disrupt forage +1."
+Faker::Hipster.paragraph(sentence_count: 2, supplemental: true) #=> "Typewriter iste ut viral kombucha voluptatem. Sint voluptates saepe. Direct trade irony chia excepturi yuccie. Biodiesel esse listicle et quam suscipit."
+Faker::Hipster.paragraph(sentence_count: 2, supplemental: false, random_sentences_to_add: 4) #=> "Selvage vhs chartreuse narwhal vinegar. Authentic vinyl truffaut carry vhs pop-up. Hammock everyday iphone locavore thundercats bitters vegan goth. Fashion axe banh mi shoreditch whatever artisan."
+Faker::Hipster.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) #=> "Deep v gluten-free unde waistcoat aperiam migas voluptas dolorum. Aut drinking illo sustainable sapiente. Direct trade fanny pack kale chips ennui semiotics."
 
-# Optional arguments: paragraph_count=3, supplemental=false
+# Optional arguments: count: 3, supplemental: false
 Faker::Hipster.paragraphs #=> ["Tilde microdosing blog cliche meggings. Intelligentsia five dollar toast forage yuccie. Master kitsch knausgaard. Try-hard everyday trust fund mumblecore.", "Normcore viral pickled. Listicle humblebrag swag tote bag. Taxidermy street hammock neutra butcher cred kale chips. Blog portland humblebrag trust fund irony.", "Single-origin coffee fixie cleanse tofu xoxo. Post-ironic tote bag ramps gluten-free locavore mumblecore hammock. Umami loko twee. Ugh kitsch before they sold out."]
-Faker::Hipster.paragraphs(1) #=> ["Skateboard cronut synth +1 fashion axe. Pop-up polaroid skateboard asymmetrical. Ennui fingerstache shoreditch before they sold out. Tattooed pitchfork ramps. Photo booth yr messenger bag raw denim bespoke locavore lomo synth."]
-Faker::Hipster.paragraphs(1, true) #=> ["Quae direct trade pbr&b quo taxidermy autem loko. Umami quas ratione migas cardigan sriracha minima. Tenetur perspiciatis pickled sed eum doloribus truffaut. Excepturi dreamcatcher meditation."]
+Faker::Hipster.paragraphs(count: 1) #=> ["Skateboard cronut synth +1 fashion axe. Pop-up polaroid skateboard asymmetrical. Ennui fingerstache shoreditch before they sold out. Tattooed pitchfork ramps. Photo booth yr messenger bag raw denim bespoke locavore lomo synth."]
+Faker::Hipster.paragraphs(count: 1, supplemental: true) #=> ["Quae direct trade pbr&b quo taxidermy autem loko. Umami quas ratione migas cardigan sriracha minima. Tenetur perspiciatis pickled sed eum doloribus truffaut. Excepturi dreamcatcher meditation."]
 ```
 
 ###Faker::Superhero

--- a/lib/faker/address.rb
+++ b/lib/faker/address.rb
@@ -11,7 +11,7 @@ module Faker
         parse('address.street_name')
       end
 
-      def street_address(include_secondary = false)
+      def street_address(include_secondary: false)
         numerify(parse('address.street_address') + (include_secondary ? ' ' + secondary_address : ''))
       end
 
@@ -23,7 +23,7 @@ module Faker
         bothify(fetch('address.building_number'))
       end
 
-      def zip_code(state_abbreviation = '')
+      def zip_code(state_abbreviation: '')
         return bothify(fetch('address.postcode')) if state_abbreviation === ''
 
         # provide a zip code that is valid for the state provided

--- a/lib/faker/avatar.rb
+++ b/lib/faker/avatar.rb
@@ -3,7 +3,7 @@ module Faker
     class << self
       SUPPORTED_FORMATS = %w(png jpg bmp)
 
-      def image(slug = nil, size = '300x300', format = 'png', set = 'set1', bgset = nil)
+      def image(slug: nil, size: '300x300', format: 'png', set: 'set1', bgset: nil)
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
         slug ||= Faker::Lorem.words.join

--- a/lib/faker/boolean.rb
+++ b/lib/faker/boolean.rb
@@ -1,7 +1,7 @@
 module Faker
   class Boolean < Base
     class << self
-      def boolean(true_ratio = 0.5)
+      def boolean(true_ratio: 0.5)
         (rand < true_ratio)
       end
     end

--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -11,26 +11,26 @@ module Faker
 
       # By default generates 10 sign isbn code in format 123456789-X
       # You can pass 13 to generate new 13 sign code
-      def isbn(base = 10)
+      def isbn(base: 10)
         base == 13 ? generate_base13_isbn : generate_base10_isbn
       end
 
       # By default generates 13 sign ean code in format 1234567890123
       # You can pass 8 to generate ean8 code
-      def ean(base = 13)
+      def ean(base: 13)
         base == 8 ? generate_base8_ean : generate_base13_ean
       end
 
       def rut
-        value = Number.number(8)
+        value = Number.number(digits: 8)
         vd = rut_verificator_digit(value)
         value << "-#{vd}"
       end
 
       # By default generates a Singaporean NRIC ID for someone
       # who is born between the age of 18 and 65.
-      def nric(min_age = 18, max_age = 65)
-        birthyear = Date.birthday(min_age, max_age).year
+      def nric(min_age: 18, max_age: 65)
+        birthyear = Date.birthday(min_age: min_age, max_age: max_age).year
         prefix = birthyear < 2000 ? 'S' : 'T'
         values = birthyear.to_s[-2..-1]
         values << regexify(/\d{5}/)

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -6,7 +6,7 @@ module Faker
         fetch('color.name')
       end
 
-      def department(max = 3, fixed_amount = false)
+      def department(max: 3, fixed_amount: false)
         num = max if fixed_amount
         num ||= 1 + rand(max)
 
@@ -27,7 +27,7 @@ module Faker
         fetch('commerce.product_name.material')
       end
 
-      def price(range=0..100.0)
+      def price(range: 0..100.0)
         random = Random::DEFAULT
         (random.rand(range) * 100).floor/100.0
       end

--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -8,10 +8,10 @@ module Faker
         Faker::Base::rand_in_range(from, to)
       end
 
-      def between_except(from:, to:, excepted:)
+      def between_except(from:, to:, except:)
         begin
           date = between(from: from, to: to)
-        end while date == excepted
+        end while date == except
 
         date
       end

--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -1,14 +1,14 @@
 module Faker
   class Date < Base
     class << self
-      def between(from:, to:)
+      def between(from: raise(ArgumentError), to: raise(ArgumentError))
         from = get_date_object(from)
         to   = get_date_object(to)
 
         Faker::Base::rand_in_range(from, to)
       end
 
-      def between_except(from:, to:, except:)
+      def between_except(from: raise(ArgumentError), to: raise(ArgumentError), except: raise(ArgumentError))
         begin
           date = between(from: from, to: to)
         end while date == except

--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -1,36 +1,36 @@
 module Faker
   class Date < Base
     class << self
-      def between(from, to)
+      def between(from:, to:)
         from = get_date_object(from)
         to   = get_date_object(to)
 
         Faker::Base::rand_in_range(from, to)
       end
 
-      def between_except(from, to, excepted)
+      def between_except(from:, to:, excepted:)
         begin
-          date = between(from, to)
+          date = between(from: from, to: to)
         end while date == excepted
 
         date
       end
 
-      def forward(days = 365)
+      def forward(days: 365)
         from = ::Date.today + 1
         to   = ::Date.today + days
 
-        between(from, to).to_date
+        between(from: from, to: to).to_date
       end
 
-      def backward(days = 365)
+      def backward(days: 365)
         from = ::Date.today - days
         to   = ::Date.today - 1
 
-        between(from, to).to_date
+        between(from: from, to: to).to_date
       end
 
-      def birthday(min_age = 18, max_age = 65)
+      def birthday(min_age: 18, max_age: 65)
         t = ::Date.today
         top_bound, bottom_bound = prepare_bounds(t, min_age, max_age)
         years = handled_leap_years(top_bound, bottom_bound)
@@ -38,7 +38,7 @@ module Faker
         from =  ::Date.new(years[0], t.month, t.day)
         to   =  ::Date.new(years[1], t.month, t.day)
 
-        between(from, to).to_date
+        between(from: from, to: to).to_date
       end
 
       private

--- a/lib/faker/file.rb
+++ b/lib/faker/file.rb
@@ -10,7 +10,7 @@ module Faker
         fetch('file.mime_type')
       end
 
-      def file_name(dir = nil, name = nil, ext = nil, directory_separator = '/')
+      def file_name(dir: nil, name: nil, ext: nil, directory_separator: '/')
 
         dir = Faker::Internet::slug unless dir
         name = Faker::Lorem::word().downcase unless name

--- a/lib/faker/hipster.rb
+++ b/lib/faker/hipster.rb
@@ -6,8 +6,8 @@ module Faker
         random_word.match(/\s/) ? word : random_word
       end
 
-      def words(num: 3, supplemental: false, spaces_allowed: false)
-        resolved_num = resolve(num)
+      def words(count: 3, supplemental: false, spaces_allowed: false)
+        resolved_num = resolve(count)
         word_list = (
           translate('faker.hipster.words') +
           (supplemental ? translate('faker.lorem.words') : [])
@@ -20,24 +20,24 @@ module Faker
       end
 
       def sentence(word_count: 4, supplemental: false, random_words_to_add: 6)
-        words(num: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
+        words(count: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
       end
 
-      def sentences(sentence_count: 3, supplemental: false)
+      def sentences(count: 3, supplemental: false)
         [].tap do |sentences|
-          1.upto(resolve(sentence_count)) do
+          1.upto(resolve(count)) do
             sentences << sentence(word_count: 3, supplemental: supplemental)
           end
         end
       end
 
       def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
-        sentences(sentence_count: resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i, supplemental: supplemental).join(' ')
+        sentences(count: resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i, supplemental: supplemental).join(' ')
       end
 
-      def paragraphs(paragraph_count: 3, supplemental: false)
+      def paragraphs(count: 3, supplemental: false)
         [].tap do |paragraphs|
-          1.upto(resolve(paragraph_count)) do
+          1.upto(resolve(count)) do
             paragraphs << paragraph(sentence_count: 3, supplemental: supplemental)
           end
         end

--- a/lib/faker/hipster.rb
+++ b/lib/faker/hipster.rb
@@ -6,7 +6,7 @@ module Faker
         random_word.match(/\s/) ? word : random_word
       end
 
-      def words(num = 3, supplemental = false, spaces_allowed = false)
+      def words(num: 3, supplemental: false, spaces_allowed: false)
         resolved_num = resolve(num)
         word_list = (
           translate('faker.hipster.words') +
@@ -19,26 +19,26 @@ module Faker
         words.each_with_index { |w, i| words[i] = word if w.match(/\s/) }
       end
 
-      def sentence(word_count = 4, supplemental = false, random_words_to_add = 6)
-        words(word_count + rand(random_words_to_add.to_i).to_i, supplemental, true).join(' ').capitalize + '.'
+      def sentence(word_count: 4, supplemental: false, random_words_to_add: 6)
+        words(num: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental, spaces_allowed: true).join(' ').capitalize + '.'
       end
 
-      def sentences(sentence_count = 3, supplemental = false)
+      def sentences(sentence_count: 3, supplemental: false)
         [].tap do |sentences|
           1.upto(resolve(sentence_count)) do
-            sentences << sentence(3, supplemental)
+            sentences << sentence(word_count: 3, supplemental: supplemental)
           end
         end
       end
 
-      def paragraph(sentence_count = 3, supplemental = false, random_sentences_to_add = 3)
-        sentences(resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i, supplemental).join(' ')
+      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
+        sentences(sentence_count: resolve(sentence_count) + rand(random_sentences_to_add.to_i).to_i, supplemental: supplemental).join(' ')
       end
 
-      def paragraphs(paragraph_count = 3, supplemental = false)
+      def paragraphs(paragraph_count: 3, supplemental: false)
         [].tap do |paragraphs|
           1.upto(resolve(paragraph_count)) do
-            paragraphs << paragraph(3, supplemental)
+            paragraphs << paragraph(sentence_count: 3, supplemental: supplemental)
           end
         end
       end

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -2,26 +2,26 @@
 module Faker
   class Internet < Base
     class << self
-      def email(name = nil)
-        [user_name(name), domain_name].join('@')
+      def email(name: nil)
+        [user_name(specifier: name), domain_name].join('@')
       end
 
-      def free_email(name = nil)
-        [user_name(name), fetch('internet.free_email')].join('@')
+      def free_email(name: nil)
+        [user_name(specifier: name), fetch('internet.free_email')].join('@')
       end
 
-      def safe_email(name = nil)
-        [user_name(name), 'example.'+ %w[org com net].shuffle.first].join('@')
+      def safe_email(name: nil)
+        [user_name(specifier: name), 'example.'+ %w[org com net].shuffle.first].join('@')
       end
 
-      def user_name(specifier = nil, separators = %w(. _))
+      def user_name(specifier: nil, separators: %w(. _))
         with_locale(:en) do
           if specifier.kind_of? String
             return specifier.scan(/\w+/).shuffle.join(separators.sample).downcase
           elsif specifier.kind_of? Integer
             tries = 0 # Don't try forever in case we get something like 1_000_000.
             begin
-              result = user_name nil, separators
+              result = user_name(separators: separators)
               tries += 1
             end while result.length < specifier and tries < 7
             until result.length >= specifier
@@ -31,7 +31,7 @@ module Faker
           elsif specifier.kind_of? Range
             tries = 0
             begin
-              result = user_name specifier.min, separators
+              result = user_name(specifier: specifier.min, separators: separators)
               tries += 1
             end while not specifier.include? result.length and tries < 7
             return result[0...specifier.max]
@@ -46,12 +46,12 @@ module Faker
         end
       end
 
-      def password(min_length = 8, max_length = 16, mix_case = true, special_chars = false)
-        temp = Lorem.characters(min_length)
+      def password(min_length: 8, max_length: 16, mix_case: true, special_chars: false)
+        temp = Lorem.characters(char_count: min_length)
         diff_length = max_length - min_length
         if diff_length > 0
           diff_rand = rand(diff_length + 1)
-          temp += Lorem.characters(diff_rand)
+          temp += Lorem.characters(char_count: diff_rand)
         end
         temp = temp[0..min_length] if min_length > 0
 
@@ -90,7 +90,7 @@ module Faker
         fetch('internet.domain_suffix')
       end
 
-      def mac_address(prefix='')
+      def mac_address(prefix: '')
         prefix_digits = prefix.split(':').map{ |d| d.to_i(16) }
         address_digits = (6 - prefix_digits.size).times.map{ rand(256) }
         (prefix_digits + address_digits).map{ |d| '%02x' % d }.join(':')
@@ -144,13 +144,13 @@ module Faker
         "#{ip_v6_address}/#{1 + rand(127)}"
       end
 
-      def url(host = domain_name, path = "/#{user_name}")
+      def url(host: domain_name, path: "/#{user_name}")
         "http://#{host}#{path}"
       end
 
-      def slug(words = nil, glue = nil)
+      def slug(words: nil, glue: nil)
         glue ||= %w[- _ .].sample
-        (words || Faker::Lorem::words(2).join(' ')).gsub(' ', glue).downcase
+        (words || Faker::Lorem::words(num: 2).join(' ')).gsub(' ', glue).downcase
       end
 
       def device_token

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -47,11 +47,11 @@ module Faker
       end
 
       def password(min_length: 8, max_length: 16, mix_case: true, special_chars: false)
-        temp = Lorem.characters(char_count: min_length)
+        temp = Lorem.characters(min_length)
         diff_length = max_length - min_length
         if diff_length > 0
           diff_rand = rand(diff_length + 1)
-          temp += Lorem.characters(char_count: diff_rand)
+          temp += Lorem.characters(diff_rand)
         end
         temp = temp[0..min_length] if min_length > 0
 
@@ -150,7 +150,7 @@ module Faker
 
       def slug(words: nil, glue: nil)
         glue ||= %w[- _ .].sample
-        (words || Faker::Lorem::words(num: 2).join(' ')).gsub(' ', glue).downcase
+        (words || Faker::Lorem::words(count: 2).join(' ')).gsub(' ', glue).downcase
       end
 
       def device_token

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -8,7 +8,7 @@ module Faker
         translate('faker.lorem.words').sample
       end
 
-      def words(num = 3, supplemental = false)
+      def words(num: 3, supplemental: false)
         resolved_num = resolve(num)
         word_list = (
           translate('faker.lorem.words') +
@@ -22,44 +22,44 @@ module Faker
         CHARACTERS.sample
       end
 
-      def characters(char_count = 255)
+      def characters(char_count: 255)
         char_count = resolve(char_count)
         return '' if char_count.to_i < 1
         Array.new(char_count) { CHARACTERS.sample }.join
       end
 
-      def sentence(word_count = 4, supplemental = false, random_words_to_add = 6)
-        words(word_count + rand(random_words_to_add.to_i), supplemental).join(' ').capitalize + '.'
+      def sentence(word_count: 4, supplemental: false, random_words_to_add: 6)
+        words(num: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(' ').capitalize + '.'
       end
 
-      def sentences(sentence_count = 3, supplemental = false)
+      def sentences(sentence_count: 3, supplemental: false)
         [].tap do |sentences|
           1.upto(resolve(sentence_count)) do
-            sentences << sentence(3, supplemental)
+            sentences << sentence(word_count: 3, supplemental: supplemental)
           end
         end
       end
 
-      def paragraph(sentence_count = 3, supplemental = false, random_sentences_to_add = 3)
-        sentences(resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental).join(' ')
+      def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
+        sentences(sentence_count: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental).join(' ')
       end
 
-      def paragraphs(paragraph_count = 3, supplemental = false)
+      def paragraphs(paragraph_count: 3, supplemental: false)
         [].tap do |paragraphs|
           1.upto(resolve(paragraph_count)) do
-            paragraphs << paragraph(3, supplemental)
+            paragraphs << paragraph(sentence_count: 3, supplemental: supplemental)
           end
         end
       end
 
-      def question(word_count = 4, supplemental = false, random_words_to_add = 6)
-        words(word_count + rand(random_words_to_add.to_i).to_i, supplemental).join(' ').capitalize + '?'
+      def question(word_count: 4, supplemental: false, random_words_to_add: 6)
+        words(num: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental).join(' ').capitalize + '?'
       end
 
-      def questions(question_count = 3, supplemental = false)
+      def questions(question_count: 3, supplemental: false)
         [].tap do |questions|
           1.upto(resolve(question_count)) do
-            questions << question(3, supplemental)
+            questions << question(word_count: 3, supplemental: supplemental)
           end
         end
       end

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -8,8 +8,8 @@ module Faker
         translate('faker.lorem.words').sample
       end
 
-      def words(num: 3, supplemental: false)
-        resolved_num = resolve(num)
+      def words(count: 3, supplemental: false)
+        resolved_num = resolve(count)
         word_list = (
           translate('faker.lorem.words') +
           (supplemental ? translate('faker.lorem.supplemental') : [])
@@ -22,43 +22,43 @@ module Faker
         CHARACTERS.sample
       end
 
-      def characters(char_count: 255)
-        char_count = resolve(char_count)
-        return '' if char_count.to_i < 1
-        Array.new(char_count) { CHARACTERS.sample }.join
+      def characters(count = 255)
+        count = resolve(count)
+        return '' if count.to_i < 1
+        Array.new(count) { CHARACTERS.sample }.join
       end
 
       def sentence(word_count: 4, supplemental: false, random_words_to_add: 6)
-        words(num: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(' ').capitalize + '.'
+        words(count: word_count + rand(random_words_to_add.to_i), supplemental: supplemental).join(' ').capitalize + '.'
       end
 
-      def sentences(sentence_count: 3, supplemental: false)
+      def sentences(count: 3, supplemental: false)
         [].tap do |sentences|
-          1.upto(resolve(sentence_count)) do
+          1.upto(resolve(count)) do
             sentences << sentence(word_count: 3, supplemental: supplemental)
           end
         end
       end
 
       def paragraph(sentence_count: 3, supplemental: false, random_sentences_to_add: 3)
-        sentences(sentence_count: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental).join(' ')
+        sentences(count: resolve(sentence_count) + rand(random_sentences_to_add.to_i), supplemental: supplemental).join(' ')
       end
 
-      def paragraphs(paragraph_count: 3, supplemental: false)
+      def paragraphs(count: 3, supplemental: false)
         [].tap do |paragraphs|
-          1.upto(resolve(paragraph_count)) do
+          1.upto(resolve(count)) do
             paragraphs << paragraph(sentence_count: 3, supplemental: supplemental)
           end
         end
       end
 
       def question(word_count: 4, supplemental: false, random_words_to_add: 6)
-        words(num: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental).join(' ').capitalize + '?'
+        words(count: word_count + rand(random_words_to_add.to_i).to_i, supplemental: supplemental).join(' ').capitalize + '?'
       end
 
-      def questions(question_count: 3, supplemental: false)
+      def questions(count: 3, supplemental: false)
         [].tap do |questions|
-          1.upto(resolve(question_count)) do
+          1.upto(resolve(count)) do
             questions << question(word_count: 3, supplemental: supplemental)
           end
         end

--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -1,31 +1,31 @@
 module Faker
   class Number < Base
     class << self
-      def number(digits)
+      def number(digits:)
         num = ''
         if digits > 1
           num = non_zero_digit
           digits -= 1
         end
-        num + leading_zero_number(digits)
+        num + leading_zero_number(digits: digits)
       end
 
-      def leading_zero_number(digits)
+      def leading_zero_number(digits:)
         (1..digits).collect {digit}.join
       end
 
-      def decimal_part digits
+      def decimal_part(digits:)
         num = ''
         if digits > 1
           num = non_zero_digit
           digits -= 1
         end
-        leading_zero_number(digits) + num
+        leading_zero_number(digits: digits) + num
       end
 
-      def decimal(l_digits, r_digits = 2)
-        l_d = self.number(l_digits)
-        r_d = self.decimal_part(r_digits)
+      def decimal(whole_digits:, decimal_digits: 2)
+        l_d = self.number(digits: whole_digits)
+        r_d = self.decimal_part(digits: decimal_digits)
         "#{l_d}.#{r_d}"
       end
 
@@ -37,23 +37,23 @@ module Faker
         rand(10).to_s
       end
 
-      def hexadecimal(digits)
+      def hexadecimal(digits:)
         hex = ""
         digits.times { hex += rand(15).to_s(16) }
         hex
       end
 
-      def between(from = 1.00, to = 5000.00)
+      def between(from: 1.00, to: 5000.00)
         Faker::Base::rand_in_range(from, to)
       end
 
-      def positive(from = 1.00, to = 5000.00)
-        random_number = between(from, to)
+      def positive(from: 1.00, to: 5000.00)
+        random_number = between(from: from, to: to)
         greater_than_zero(random_number)
       end
 
-      def negative(from = -5000.00, to = -1.00)
-        random_number = between(from, to)
+      def negative(from: -5000.00, to: -1.00)
+        random_number = between(from: from, to: to)
         less_than_zero(random_number)
       end
 

--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -1,7 +1,7 @@
 module Faker
   class Number < Base
     class << self
-      def number(digits:)
+      def number(digits: raise(ArgumentError))
         num = ''
         if digits > 1
           num = non_zero_digit
@@ -10,11 +10,11 @@ module Faker
         num + leading_zero_number(digits: digits)
       end
 
-      def leading_zero_number(digits:)
+      def leading_zero_number(digits: raise(ArgumentError))
         (1..digits).collect {digit}.join
       end
 
-      def decimal_part(digits:)
+      def decimal_part(digits: raise(ArgumentError))
         num = ''
         if digits > 1
           num = non_zero_digit
@@ -23,7 +23,7 @@ module Faker
         leading_zero_number(digits: digits) + num
       end
 
-      def decimal(whole_digits:, decimal_digits: 2)
+      def decimal(whole_digits: raise(ArgumentError), decimal_digits: 2)
         l_d = self.number(digits: whole_digits)
         r_d = self.decimal_part(digits: decimal_digits)
         "#{l_d}.#{r_d}"
@@ -37,7 +37,7 @@ module Faker
         rand(10).to_s
       end
 
-      def hexadecimal(digits:)
+      def hexadecimal(digits: raise(ArgumentError))
         hex = ""
         digits.times { hex += rand(15).to_s(16) }
         hex

--- a/lib/faker/phone_number.rb
+++ b/lib/faker/phone_number.rb
@@ -37,8 +37,8 @@ module Faker
 
       # US only
       # Can be used for both extensions and last four digits of phone number.
-      # Since extensions can be of variable length, this method taks a length parameter
-      def subscriber_number(length = 4)
+      # Since extensions can be of variable length, this method takes a length parameter
+      def subscriber_number(length: 4)
         begin
           rand.to_s[2..(1 + length)]
         rescue I18n::MissingTranslationData

--- a/lib/faker/placeholdit.rb
+++ b/lib/faker/placeholdit.rb
@@ -3,7 +3,7 @@ module Faker
     class << self
       SUPPORTED_FORMATS = %w(png jpg gif jpeg)
 
-      def image(size = '300x300', format = 'png', background_color = '000', text_color = nil, text = nil)
+      def image(size: '300x300', format: 'png', background_color: '000', text_color: nil, text: nil)
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
         raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.match(/((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/)

--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -11,7 +11,7 @@ module Faker
     }
 
     class << self
-      def between(from:, to:, period: :all)
+      def between(from: raise(ArgumentError), to: raise(ArgumentError), period: :all)
         date_with_random_time(super(from: from, to: to), period)
       end
 

--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -11,16 +11,16 @@ module Faker
     }
 
     class << self
-      def between(from, to, period = :all)
-        date_with_random_time(super(from, to), period)
+      def between(from:, to:, period: :all)
+        date_with_random_time(super(from: from, to: to), period)
       end
 
-      def forward(days = 365, period = :all)
-        date_with_random_time(super(days), period)
+      def forward(days: 365, period: :all)
+        date_with_random_time(super(days: days), period)
       end
 
-      def backward(days = 365, period = :all)
-        date_with_random_time(super(days), period)
+      def backward(days: 365, period: :all)
+        date_with_random_time(super(days: days), period)
       end
 
       private

--- a/test/test_avatar.rb
+++ b/test/test_avatar.rb
@@ -10,34 +10,34 @@ class TestFakerAvatar < Test::Unit::TestCase
   end
 
   def test_avatar_with_param
-    assert @tester.image('faker').match(/https:\/\/robohash\.org\/(.+)\.png/)[1] == 'faker'
+    assert @tester.image(slug: 'faker').match(/https:\/\/robohash\.org\/(.+)\.png/)[1] == 'faker'
   end
 
   def test_avatar_with_correct_size
-    assert @tester.image('faker', '150x320').match(/https:\/\/robohash\.org\/faker\.png\?size=(.+)&.*/)[1] == '150x320'
+    assert @tester.image(slug: 'faker', size: '150x320').match(/https:\/\/robohash\.org\/faker\.png\?size=(.+)&.*/)[1] == '150x320'
   end
 
   def test_avatar_with_incorrect_size
     assert_raise ArgumentError do
-      @tester.image(nil, '150x320z')
+      @tester.image(size: '150x320z')
     end
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image('faker', '300x300', 'jpg').match(/https:\/\/robohash\.org\/faker\.jpg/)
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg').match(/https:\/\/robohash\.org\/faker\.jpg/)
   end
 
   def test_avatar_with_incorrect_format
     assert_raise ArgumentError do
-      @tester.image(nil, '300x300', 'wrong_format')
+      @tester.image(size: '300x300', format: 'wrong_format')
     end
   end
 
   def test_avatar_with_set
-    assert @tester.image('faker', '300x300', 'jpg', 'set2').match(/https:\/\/robohash\.org\/faker\.jpg.*set=set2/)
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set2').match(/https:\/\/robohash\.org\/faker\.jpg.*set=set2/)
   end
 
   def test_avatar_with_bgset
-    assert @tester.image('faker', '300x300', 'jpg', 'set1', 'bg1').match(/https:\/\/robohash\.org\/faker\.jpg.*bgset=bg1/)
+    assert @tester.image(slug: 'faker', size: '300x300', format: 'jpg', set: 'set1', bgset: 'bg1').match(/https:\/\/robohash\.org\/faker\.jpg.*bgset=bg1/)
   end
 end

--- a/test/test_en_us_locale.rb
+++ b/test/test_en_us_locale.rb
@@ -19,7 +19,7 @@ class TestEnUsLocale < Test::Unit::TestCase
   def test_subscriber_number_method
     assert Faker::PhoneNumber.subscriber_number.is_a? String
     assert_equal Faker::PhoneNumber.subscriber_number.length, 4
-    assert_equal Faker::PhoneNumber.subscriber_number(10).length, 10
+    assert_equal Faker::PhoneNumber.subscriber_number(length: 10).length, 10
     assert_equal Faker::PhoneNumber.method(:extension), Faker::PhoneNumber.method(:subscriber_number)
   end
 
@@ -40,34 +40,34 @@ class TestEnUsLocale < Test::Unit::TestCase
   end
 
   def test_us_invalid_state_raises_exception
-    assert_raise I18n::MissingTranslationData do Faker::Address.zip_code('NA') end
+    assert_raise I18n::MissingTranslationData do Faker::Address.zip_code(state_abbreviation: 'NA') end
   end
 
   def test_us_zip_codes_match_state
     state_abbr = 'AZ'
     expected = /^850\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
 
     # disjointed ranges for these states
     # http://www.fincen.gov/forms/files/us_state_territory_zip_codes.pdf
     state_abbr = 'AR'
     expected = /^717\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
     state_abbr = 'GA'
     expected = /^301\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
     state_abbr = 'MA'
     expected = /^026\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
     state_abbr = 'NY'
     expected = /^122\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
     state_abbr = 'TX'
     expected = /^798\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
     state_abbr = 'VA'
     expected = /^222\d\d$/
-    assert_match(expected, Faker::Address.zip_code(state_abbr))
+    assert_match(expected, Faker::Address.zip_code(state_abbreviation: state_abbr))
   end
 
   def test_valid_id_number

--- a/test/test_faker_code.rb
+++ b/test/test_faker_code.rb
@@ -14,7 +14,7 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_default_isbn13_regexp
-    assert @tester.isbn(13).match(/^\d{12}-\d$/)
+    assert @tester.isbn(base: 13).match(/^\d{12}-\d$/)
   end
 
   def test_default_ean_regexp
@@ -22,7 +22,7 @@ class TestFakerCode < Test::Unit::TestCase
   end
 
   def test_default_ean8_regexp
-    assert @tester.ean(8).match(/^\d{8}$/)
+    assert @tester.ean(base: 8).match(/^\d{8}$/)
   end
 
   def test_rut

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -15,11 +15,11 @@ class TestFakerCommerce < Test::Unit::TestCase
   end
 
   def test_single_department_should_not_contain_separators
-    assert_match(/\A[A-Za-z]+\z/, @tester.department(1))
+    assert_match(/\A[A-Za-z]+\z/, @tester.department(max: 1))
   end
 
   def test_department_should_have_ampersand_as_default_separator
-    assert_match ' & ', @tester.department(2, true)
+    assert_match ' & ', @tester.department(max: 2, fixed_amount: true)
   end
 
   def test_department_should_accept_localized_separator
@@ -36,23 +36,23 @@ class TestFakerCommerce < Test::Unit::TestCase
     I18n.backend.store_translations(:xy, data)
     I18n.config.available_locales += [ :xy ]
     I18n.with_locale(:xy) do
-      assert_match ' + ', @tester.department(2, true)
+      assert_match ' + ', @tester.department(max: 2, fixed_amount: true)
     end
     I18n.config.available_locales = @old_locales
   end
 
   def test_department_should_have_exact_number_of_categories_when_fixed_amount
-    assert_match(/\A([A-Za-z]+, ){8}[A-Za-z]+ & [A-Za-z]+\z/, @tester.department(10, true))
+    assert_match(/\A([A-Za-z]+, ){8}[A-Za-z]+ & [A-Za-z]+\z/, @tester.department(max: 10, fixed_amount: true))
   end
 
   def test_department_should_never_exceed_the_max_number_of_categories_when_random_amount
     100.times do
-      assert_match(/\A([A-Za-z]+(, | & )){0,5}[A-Za-z]+\z/, @tester.department(6))
+      assert_match(/\A([A-Za-z]+(, | & )){0,5}[A-Za-z]+\z/, @tester.department(max: 6))
     end
   end
 
   def test_department_should_have_no_duplicate_categories
-    department = @tester.department(10, true)
+    department = @tester.department(max: 10, fixed_amount: true)
 
     departments = department.split(/[,& ]+/)
     assert_equal departments, departments.uniq
@@ -68,9 +68,9 @@ class TestFakerCommerce < Test::Unit::TestCase
 
   def test_price
     assert_includes 0..100, @tester.price
-    assert_instance_of Float, @tester.price(5..6)
-    assert_includes 5..6, @tester.price(5..6)
-    assert_includes 990...1000, @tester.price(990...1000)
+    assert_instance_of Float, @tester.price(range: 5..6)
+    assert_includes 5..6, @tester.price(range: 5..6)
+    assert_includes 990...1000, @tester.price(range: 990...1000)
   end
 
   def test_price_with_srand

--- a/test/test_faker_date.rb
+++ b/test/test_faker_date.rb
@@ -19,11 +19,11 @@ class TestFakerDate < Test::Unit::TestCase
   def test_between_except
     from = Date.parse("2012-01-01")
     to   = Date.parse("2012-01-05")
-    excepted = Date.parse("2012-01-03")
+    except = Date.parse("2012-01-03")
 
     100.times do
-      random_date = @tester.between_except(from: from, to: to, excepted: excepted)
-      assert random_date != excepted, "Expected != \"#{excepted}\", but got #{random_date}"
+      random_date = @tester.between_except(from: from, to: to, except: except)
+      assert random_date != except, "Expected != \"#{except}\", but got #{random_date}"
     end
   end
 

--- a/test/test_faker_date.rb
+++ b/test/test_faker_date.rb
@@ -10,7 +10,7 @@ class TestFakerDate < Test::Unit::TestCase
     to   = Date.parse("2013-01-01")
 
     100.times do
-      random_date = @tester.between(from, to)
+      random_date = @tester.between(from: from, to: to)
       assert random_date >= from, "Expected >= \"#{from}\", but got #{random_date}"
       assert random_date <= to  , "Expected <= \"#{to}\", but got #{random_date}"
     end
@@ -22,7 +22,7 @@ class TestFakerDate < Test::Unit::TestCase
     excepted = Date.parse("2012-01-03")
 
     100.times do
-      random_date = @tester.between_except(from, to, excepted)
+      random_date = @tester.between_except(from: from, to: to, excepted: excepted)
       assert random_date != excepted, "Expected != \"#{excepted}\", but got #{random_date}"
     end
   end
@@ -31,7 +31,7 @@ class TestFakerDate < Test::Unit::TestCase
     today = Date.today
 
     100.times do
-      random_date = @tester.forward(5)
+      random_date = @tester.forward(days: 5)
       assert random_date > today, "Expected > \"#{today}\", but got #{random_date}"
     end
   end
@@ -40,15 +40,15 @@ class TestFakerDate < Test::Unit::TestCase
     today = Date.today
 
     100.times do
-      random_date = @tester.backward(5)
+      random_date = @tester.backward(days: 5)
       assert random_date < today, "Expected < \"#{today}\", but got #{random_date}"
     end
   end
 
   def test_return_type
-    random_forward  = @tester.forward(5)
-    random_backward = @tester.backward(5)
-    random_between  = @tester.between(Date.today, Date.today + 5)
+    random_forward  = @tester.forward(days: 5)
+    random_backward = @tester.backward(days: 5)
+    random_between  = @tester.between(from: Date.today, to: Date.today + 5)
 
     [random_forward, random_backward, random_between].each do |result|
       assert result.is_a?(Date), "Expected a Date object, but got #{result.class}"
@@ -57,7 +57,7 @@ class TestFakerDate < Test::Unit::TestCase
 
   def test_invalid_date
     assert_raise ArgumentError do
-      @tester.between("9999-99-99", "9999-99-99")
+      @tester.between(from: "9999-99-99", to: "9999-99-99")
     end
   end
 
@@ -68,7 +68,7 @@ class TestFakerDate < Test::Unit::TestCase
       t = Date.today
       date_min = Date.new(t.year - min, t.month, t.day)
       date_max = Date.new(t.year - max, t.month, t.day)
-      birthday = @tester.birthday(min, max)
+      birthday = @tester.birthday(min_age: min, max_age: max)
       assert birthday >= date_max, "Expect > \"#{date_max}\", but got #{birthday}"
       assert birthday <= date_min, "Expect > \"#{date_max}\", but got #{birthday}"
     end

--- a/test/test_faker_date.rb
+++ b/test/test_faker_date.rb
@@ -86,4 +86,11 @@ class TestFakerDate < Test::Unit::TestCase
       assert birthday < date_min, "Expect > \"#{date_max}\", but got #{birthday}"
     end
   end
+
+  def test_missing_required_args
+    assert_raise ArgumentError do
+      @tester.between
+      @tester.between_except
+    end
+  end
 end

--- a/test/test_faker_hipster.rb
+++ b/test/test_faker_hipster.rb
@@ -11,19 +11,19 @@ class TestFakerHipster < Test::Unit::TestCase
 
   # Words delivered by a standard request should be on the standard wordlist.
   def test_words
-    @words = @tester.words(num: 1000)
+    @words = @tester.words(count: 1000)
     @words.each { |w| assert @standard_wordlist.include?(w) }
   end
 
   # Words should not return any word with spaces
   def test_words_without_spaces
-    @words = @tester.words(num: 1000)
+    @words = @tester.words(count: 1000)
     @words.each { |w| assert !w.match(/\s/) }
   end
 
   # Words requested from the supplemental list should all be in that list.
   def test_supplemental_words
-    @words = @tester.words(num: 10000, supplemental: true)
+    @words = @tester.words(count: 10000, supplemental: true)
     @words.each { |w| assert @complete_wordlist.include?(w) }
   end
 
@@ -38,15 +38,15 @@ class TestFakerHipster < Test::Unit::TestCase
   end
 
   def test_exact_count_param
-    assert(@tester.words(num: 2).length == 2)
-    assert(@tester.sentences(sentence_count: 2).length == 2)
-    assert(@tester.paragraphs(paragraph_count: 2).length == 2)
+    assert(@tester.words(count: 2).length == 2)
+    assert(@tester.sentences(count: 2).length == 2)
+    assert(@tester.paragraphs(count: 2).length == 2)
   end
 
   def test_range_count_param
-    ws = @tester.words(num: 2..5)
-    ss = @tester.sentences(sentence_count: 2..5)
-    ps = @tester.paragraphs(paragraph_count: 2..5)
+    ws = @tester.words(count: 2..5)
+    ss = @tester.sentences(count: 2..5)
+    ps = @tester.paragraphs(count: 2..5)
 
     assert(2 <= ws.length && ws.length <= 5)
     assert(2 <= ss.length && ss.length <= 5)
@@ -54,9 +54,9 @@ class TestFakerHipster < Test::Unit::TestCase
   end
 
   def test_array_count_param
-    ws = @tester.words(num: [1,4])
-    ss = @tester.sentences(sentence_count: [1,4])
-    ps = @tester.paragraphs(paragraph_count: [1,4])
+    ws = @tester.words(count: [1,4])
+    ss = @tester.sentences(count: [1,4])
+    ps = @tester.paragraphs(count: [1,4])
 
     assert(ws.length == 1 || ws.length == 4)
     assert(ss.length == 1 || ss.length == 4)
@@ -64,9 +64,9 @@ class TestFakerHipster < Test::Unit::TestCase
   end
 
   def test_words_with_large_count_params
-    exact = @tester.words(num: 500)
-    range = @tester.words(num: 250..500)
-    array = @tester.words(num: [250, 500])
+    exact = @tester.words(count: 500)
+    range = @tester.words(count: 250..500)
+    array = @tester.words(count: [250, 500])
 
     assert(exact.length == 500)
     assert(250 <= range.length && range.length <= 500)

--- a/test/test_faker_hipster.rb
+++ b/test/test_faker_hipster.rb
@@ -11,45 +11,42 @@ class TestFakerHipster < Test::Unit::TestCase
 
   # Words delivered by a standard request should be on the standard wordlist.
   def test_words
-    @words = @tester.words(1000)
+    @words = @tester.words(num: 1000)
     @words.each { |w| assert @standard_wordlist.include?(w) }
   end
 
   # Words should not return any word with spaces
   def test_words_without_spaces
-    @words = @tester.words(1000)
+    @words = @tester.words(num: 1000)
     @words.each { |w| assert !w.match(/\s/) }
   end
 
   # Words requested from the supplemental list should all be in that list.
   def test_supplemental_words
-    @words = @tester.words(10000, true)
+    @words = @tester.words(num: 10000, supplemental: true)
     @words.each { |w| assert @complete_wordlist.include?(w) }
   end
 
   # Faker::Hipster.word generates random word from standart wordlist
   def test_word
-    @tester = Faker::Hipster
-    @standard_wordlist = I18n.translate('faker.hipster.words')
     1000.times { assert @standard_wordlist.include?(@tester.word) }
   end
 
   # Word should not return any word with spaces
   def test_word_without_spaces
-    @tester = Faker::Hipster
     1000.times { assert !@tester.word.match(/\s/) }
   end
 
   def test_exact_count_param
-    assert(@tester.words(2).length == 2)
-    assert(@tester.sentences(2).length == 2)
-    assert(@tester.paragraphs(2).length == 2)
+    assert(@tester.words(num: 2).length == 2)
+    assert(@tester.sentences(sentence_count: 2).length == 2)
+    assert(@tester.paragraphs(paragraph_count: 2).length == 2)
   end
 
   def test_range_count_param
-    ws = @tester.words(2..5)
-    ss = @tester.sentences(2..5)
-    ps = @tester.paragraphs(2..5)
+    ws = @tester.words(num: 2..5)
+    ss = @tester.sentences(sentence_count: 2..5)
+    ps = @tester.paragraphs(paragraph_count: 2..5)
 
     assert(2 <= ws.length && ws.length <= 5)
     assert(2 <= ss.length && ss.length <= 5)
@@ -57,9 +54,9 @@ class TestFakerHipster < Test::Unit::TestCase
   end
 
   def test_array_count_param
-    ws = @tester.words([1,4])
-    ss = @tester.sentences([1,4])
-    ps = @tester.paragraphs([1,4])
+    ws = @tester.words(num: [1,4])
+    ss = @tester.sentences(sentence_count: [1,4])
+    ps = @tester.paragraphs(paragraph_count: [1,4])
 
     assert(ws.length == 1 || ws.length == 4)
     assert(ss.length == 1 || ss.length == 4)
@@ -67,9 +64,9 @@ class TestFakerHipster < Test::Unit::TestCase
   end
 
   def test_words_with_large_count_params
-    exact = @tester.words(500)
-    range = @tester.words(250..500)
-    array = @tester.words([250, 500])
+    exact = @tester.words(num: 500)
+    range = @tester.words(num: 250..500)
+    array = @tester.words(num: [250, 500])
 
     assert(exact.length == 500)
     assert(250 <= range.length && range.length <= 500)

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -23,19 +23,19 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_user_name_with_string_arg
-    assert @tester.user_name('bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+    assert @tester.user_name(specifier: 'bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
   end
 
   def test_user_name_with_integer_arg
     (1..32).each do |min_length|
-      assert @tester.user_name(min_length).length >= min_length
+      assert @tester.user_name(specifier: min_length).length >= min_length
     end
   end
 
   def test_user_name_with_closed_range_arg
     (1..32).each do |min_length|
       (min_length..32).each do |max_length|
-        l = @tester.user_name((min_length..max_length)).length
+        l = @tester.user_name(specifier: (min_length..max_length)).length
         assert l >= min_length
         assert l <= max_length
       end
@@ -45,7 +45,7 @@ class TestFakerInternet < Test::Unit::TestCase
   def test_user_name_with_open_range_arg
     (1..32).each do |min_length|
       (min_length+1..33).each do |max_length|
-        l = @tester.user_name((min_length...max_length)).length
+        l = @tester.user_name(specifier: (min_length...max_length)).length
         assert l >= min_length
         assert l <= max_length-1
       end
@@ -55,7 +55,7 @@ class TestFakerInternet < Test::Unit::TestCase
   def test_user_name_with_range_and_separators
     (1..32).each do |min_length|
       (min_length+1..33).each do |max_length|
-        u = @tester.user_name((min_length...max_length), %w(=))
+        u = @tester.user_name(specifier: (min_length...max_length), separators: %w(=))
         assert u.length.between? min_length, max_length-1
         assert u.match(/\A[a-z]+((=)?[a-z]*)*\z/)
       end
@@ -68,14 +68,14 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_password_with_integer_arg
     (1..32).each do |min_length|
-      assert @tester.password(min_length).length >= min_length
+      assert @tester.password(min_length: min_length).length >= min_length
     end
   end
 
   def test_password_max_with_integer_arg
     (1..32).each do |min_length|
       max_length = min_length + 4
-      assert @tester.password(min_length, max_length).length <= max_length
+      assert @tester.password(min_length: min_length, max_length: max_length).length <= max_length
     end
   end
 
@@ -84,15 +84,15 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_password_without_mixed_case
-    assert @tester.password(8, 12, false).match(/[^A-Z]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: false).match(/[^A-Z]+/)
   end
 
   def test_password_with_special_chars
-    assert @tester.password(8, 12, true, true).match(/[!@#\$%\^&\*]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: true, special_chars: true).match(/[!@#\$%\^&\*]+/)
   end
 
   def test_password_without_special_chars
-    assert @tester.password(8, 12, true).match(/[^!@#\$%\^&\*]+/)
+    assert @tester.password(min_length: 8, max_length: 12, mix_case: true).match(/[^!@#\$%\^&\*]+/)
   end
 
   def test_domain_name
@@ -157,14 +157,14 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_mac_address
     assert_equal 5, @tester.mac_address.count(':')
-    assert_equal 5, @tester.mac_address("").count(':')
+    assert_equal 5, @tester.mac_address(prefix: "").count(':')
 
     100.times do
       assert @tester.mac_address.split(':').map{|d| d.to_i(16)}.max <= 255
     end
 
-    assert @tester.mac_address("fa:fa:fa").start_with?("fa:fa:fa")
-    assert @tester.mac_address("01:02").start_with?("01:02")
+    assert @tester.mac_address(prefix: "fa:fa:fa").start_with?("fa:fa:fa")
+    assert @tester.mac_address(prefix: "01:02").start_with?("01:02")
   end
 
   def test_ip_v6_address
@@ -188,15 +188,15 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_slug_with_content_arg
-    assert @tester.slug('Foo bAr baZ').match(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
+    assert @tester.slug(words: 'Foo bAr baZ').match(/^foo(_|\.|\-)bar(_|\.|\-)baz$/)
   end
 
   def test_slug_with_glue_arg
-    assert @tester.slug(nil, '+').match(/^[a-z]+\+[a-z]+$/)
+    assert @tester.slug(glue: '+').match(/^[a-z]+\+[a-z]+$/)
   end
 
   def test_url
-    assert @tester.url('domain.com', '/username').match(/^http:\/\/domain\.com\/username$/)
+    assert @tester.url(host: 'domain.com', path: '/username').match(/^http:\/\/domain\.com\/username$/)
   end
 
   def test_device_token

--- a/test/test_faker_lorem.rb
+++ b/test/test_faker_lorem.rb
@@ -22,24 +22,24 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_characters_negatives
-    assert_equal '', @tester.characters(-1)
-    assert_equal '', @tester.characters((-2..-1))
-    assert_equal '', @tester.characters([-1, -2])
+    assert_equal '', @tester.characters(char_count: -1)
+    assert_equal '', @tester.characters(char_count: (-2..-1))
+    assert_equal '', @tester.characters(char_count: [-1, -2])
   end
 
   def test_characters_with_args
-    100.times { assert @tester.characters(500).length == 500 }
+    100.times { assert @tester.characters(char_count: 500).length == 500 }
   end
 
   # Words delivered by a standard request should be on the standard wordlist.
   def test_standard_words
-    @words = @tester.words(1000)
+    @words = @tester.words(num: 1000)
     @words.each {|w| assert @standard_wordlist.include?(w) }
   end
 
   # Words requested from the supplemental list should all be in that list.
   def test_supplemental_words
-    @words = @tester.words(10000, true)
+    @words = @tester.words(num: 10000, supplemental: true)
     @words.each {|w| assert @complete_wordlist.include?(w) }
   end
 
@@ -51,17 +51,17 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_exact_count_param
-    assert(@tester.characters(2).length == 2)
-    assert(@tester.words(2).length == 2)
-    assert(@tester.sentences(2).length == 2)
-    assert(@tester.paragraphs(2).length == 2)
+    assert(@tester.characters(char_count: 2).length == 2)
+    assert(@tester.words(num: 2).length == 2)
+    assert(@tester.sentences(sentence_count: 2).length == 2)
+    assert(@tester.paragraphs(paragraph_count: 2).length == 2)
   end
 
   def test_range_count_param
-    cs = @tester.characters(2..5)
-    ws = @tester.words(2..5)
-    ss = @tester.sentences(2..5)
-    ps = @tester.paragraphs(2..5)
+    cs = @tester.characters(char_count: 2..5)
+    ws = @tester.words(num: 2..5)
+    ss = @tester.sentences(sentence_count: 2..5)
+    ps = @tester.paragraphs(paragraph_count: 2..5)
 
     assert(2 <= cs.length && cs.length <= 5)
     assert(2 <= ws.length && ws.length <= 5)
@@ -70,10 +70,10 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_exclusive_range_count_param
-    cs = @tester.characters(2...3)
-    ws = @tester.words(2...3)
-    ss = @tester.sentences(2...3)
-    ps = @tester.paragraphs(2...3)
+    cs = @tester.characters(char_count: 2...3)
+    ws = @tester.words(num: 2...3)
+    ss = @tester.sentences(sentence_count: 2...3)
+    ps = @tester.paragraphs(paragraph_count: 2...3)
 
     assert_equal(2, cs.length)
     assert_equal(2, ws.length)
@@ -82,10 +82,10 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_array_count_param
-    cs = @tester.characters([1,4])
-    ws = @tester.words([1,4])
-    ss = @tester.sentences([1,4])
-    ps = @tester.paragraphs([1,4])
+    cs = @tester.characters(char_count: [1,4])
+    ws = @tester.words(num: [1,4])
+    ss = @tester.sentences(sentence_count: [1,4])
+    ps = @tester.paragraphs(paragraph_count: [1,4])
 
     assert(cs.length == 1 || cs.length == 4)
     assert(ws.length == 1 || ws.length == 4)
@@ -94,9 +94,9 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_words_with_large_count_params
-    exact = @tester.words(500)
-    range = @tester.words(250..500)
-    array = @tester.words([250, 500])
+    exact = @tester.words(num: 500)
+    range = @tester.words(num: 250..500)
+    array = @tester.words(num: [250, 500])
 
     assert(exact.length == 500)
     assert(250 <= range.length && range.length <= 500)

--- a/test/test_faker_lorem.rb
+++ b/test/test_faker_lorem.rb
@@ -22,24 +22,24 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_characters_negatives
-    assert_equal '', @tester.characters(char_count: -1)
-    assert_equal '', @tester.characters(char_count: (-2..-1))
-    assert_equal '', @tester.characters(char_count: [-1, -2])
+    assert_equal '', @tester.characters(-1)
+    assert_equal '', @tester.characters((-2..-1))
+    assert_equal '', @tester.characters([-1, -2])
   end
 
   def test_characters_with_args
-    100.times { assert @tester.characters(char_count: 500).length == 500 }
+    100.times { assert @tester.characters(500).length == 500 }
   end
 
   # Words delivered by a standard request should be on the standard wordlist.
   def test_standard_words
-    @words = @tester.words(num: 1000)
+    @words = @tester.words(count: 1000)
     @words.each {|w| assert @standard_wordlist.include?(w) }
   end
 
   # Words requested from the supplemental list should all be in that list.
   def test_supplemental_words
-    @words = @tester.words(num: 10000, supplemental: true)
+    @words = @tester.words(count: 10000, supplemental: true)
     @words.each {|w| assert @complete_wordlist.include?(w) }
   end
 
@@ -51,17 +51,17 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_exact_count_param
-    assert(@tester.characters(char_count: 2).length == 2)
-    assert(@tester.words(num: 2).length == 2)
-    assert(@tester.sentences(sentence_count: 2).length == 2)
-    assert(@tester.paragraphs(paragraph_count: 2).length == 2)
+    assert(@tester.characters(2).length == 2)
+    assert(@tester.words(count: 2).length == 2)
+    assert(@tester.sentences(count: 2).length == 2)
+    assert(@tester.paragraphs(count: 2).length == 2)
   end
 
   def test_range_count_param
-    cs = @tester.characters(char_count: 2..5)
-    ws = @tester.words(num: 2..5)
-    ss = @tester.sentences(sentence_count: 2..5)
-    ps = @tester.paragraphs(paragraph_count: 2..5)
+    cs = @tester.characters(2..5)
+    ws = @tester.words(count: 2..5)
+    ss = @tester.sentences(count: 2..5)
+    ps = @tester.paragraphs(count: 2..5)
 
     assert(2 <= cs.length && cs.length <= 5)
     assert(2 <= ws.length && ws.length <= 5)
@@ -70,10 +70,10 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_exclusive_range_count_param
-    cs = @tester.characters(char_count: 2...3)
-    ws = @tester.words(num: 2...3)
-    ss = @tester.sentences(sentence_count: 2...3)
-    ps = @tester.paragraphs(paragraph_count: 2...3)
+    cs = @tester.characters(2...3)
+    ws = @tester.words(count: 2...3)
+    ss = @tester.sentences(count: 2...3)
+    ps = @tester.paragraphs(count: 2...3)
 
     assert_equal(2, cs.length)
     assert_equal(2, ws.length)
@@ -82,10 +82,10 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_array_count_param
-    cs = @tester.characters(char_count: [1,4])
-    ws = @tester.words(num: [1,4])
-    ss = @tester.sentences(sentence_count: [1,4])
-    ps = @tester.paragraphs(paragraph_count: [1,4])
+    cs = @tester.characters([1,4])
+    ws = @tester.words(count: [1,4])
+    ss = @tester.sentences(count: [1,4])
+    ps = @tester.paragraphs(count: [1,4])
 
     assert(cs.length == 1 || cs.length == 4)
     assert(ws.length == 1 || ws.length == 4)
@@ -94,9 +94,9 @@ class TestFakerLorem < Test::Unit::TestCase
   end
 
   def test_words_with_large_count_params
-    exact = @tester.words(num: 500)
-    range = @tester.words(num: 250..500)
-    array = @tester.words(num: [250, 500])
+    exact = @tester.words(count: 500)
+    range = @tester.words(count: 250..500)
+    array = @tester.words(count: [250, 500])
 
     assert(exact.length == 500)
     assert(250 <= range.length && range.length <= 500)

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -104,4 +104,13 @@ class TestFakerNumber < Test::Unit::TestCase
       end
     end
   end
+
+  def test_missing_required_args
+    assert_raise ArgumentError do
+      @tester.number
+      @tester.leading_zero_number
+      @tester.decimal
+      @tester.hexadecimal
+    end
+  end
 end

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -7,21 +7,21 @@ class TestFakerNumber < Test::Unit::TestCase
   end
 
   def test_number
-    assert @tester.number(10).match(/[0-9]{10}/)
+    assert @tester.number(digits: 10).match(/[0-9]{10}/)
 
     10.times do |digits|
       digits += 1
-      assert @tester.number(digits).match(/^[0-9]{#{digits}}$/)
+      assert @tester.number(digits: digits).match(/^[0-9]{#{digits}}$/)
     end
 
-    assert @tester.number(10).length == 10
-    assert @tester.number(1).length == 1
-    assert @tester.number(0) == ""
+    assert @tester.number(digits: 10).length == 10
+    assert @tester.number(digits: 1).length == 1
+    assert @tester.number(digits: 0) == ""
   end
 
   def test_decimal
-    assert @tester.decimal(2).match(/[0-9]{2}\.[0-9]{2}/)
-    assert @tester.decimal(4, 5).match(/[0-9]{4}\.[0-9]{5}/)
+    assert @tester.decimal(whole_digits: 2).match(/[0-9]{2}\.[0-9]{2}/)
+    assert @tester.decimal(whole_digits: 4, decimal_digits: 5).match(/[0-9]{4}\.[0-9]{5}/)
   end
 
   def test_digit
@@ -46,7 +46,7 @@ class TestFakerNumber < Test::Unit::TestCase
 
   def test_between
     100.times do
-      random_number = @tester.between(-50, 50)
+      random_number = @tester.between(from: -50, to: 50)
       assert random_number >= -50, "Expected >= -50, but got #{random_number}"
       assert random_number <=  50, "Expected <= 50, but got #{random_number}"
     end
@@ -54,7 +54,7 @@ class TestFakerNumber < Test::Unit::TestCase
 
   def test_positive
     100.times do
-      random_number = @tester.positive(1, 100)
+      random_number = @tester.positive(from: 1, to: 100)
       assert random_number >= 1,   "Expected >= 1, but got #{random_number}"
       assert random_number <= 100, "Expected <= 100, but got #{random_number}"
     end
@@ -62,45 +62,45 @@ class TestFakerNumber < Test::Unit::TestCase
 
   def test_negative
     100.times do
-      random_number = @tester.negative(-1, -100)
+      random_number = @tester.negative(from: -1, to: -100)
       assert random_number <= -1,   "Expected <= -1, but got #{random_number}"
       assert random_number >= -100, "Expected >= -100, but got #{random_number}"
     end
   end
 
   def test_force_positive
-    random_number = @tester.positive(-1, -100)
+    random_number = @tester.positive(from: -1, to: -100)
     assert random_number >= 1,   "Expected >= 1, but got #{random_number}"
     assert random_number <= 100, "Expected <= 100, but got #{random_number}"
   end
 
   def test_force_negative
-    random_number = @tester.negative(1, 100)
+    random_number = @tester.negative(from: 1, to: 100)
     assert random_number <= -1,   "Expected <= -1, but got #{random_number}"
     assert random_number >= -100, "Expected >= -100, but got #{random_number}"
   end
 
   def test_parameters_order
-    random_number = @tester.between(100, 1)
+    random_number = @tester.between(from: 100, to: 1)
     assert random_number >= 1,   "Expected >= 1, but got #{random_number}"
     assert random_number <= 100, "Expected <= 100, but got #{random_number}"
   end
 
   def test_hexadecimal
-    assert @tester.hexadecimal(4).match(/[0-9a-f]{4}/)
-    assert @tester.hexadecimal(7).match(/[0-9a-f]{7}/)
+    assert @tester.hexadecimal(digits: 4).match(/[0-9a-f]{4}/)
+    assert @tester.hexadecimal(digits: 7).match(/[0-9a-f]{7}/)
   end
 
   def test_insignificant_zero
     @tester.stub :digit, 0 do
-      assert_equal '0', @tester.number(1)
+      assert_equal '0', @tester.number(digits: 1)
       100.times do
-        assert_match (/^[1-9]0/), @tester.number(2)
+        assert_match (/^[1-9]0/), @tester.number(digits: 2)
       end
 
-      assert_equal '0.0', @tester.decimal(1,1)
+      assert_equal '0.0', @tester.decimal(whole_digits: 1, decimal_digits: 1)
       100.times do
-        assert_match (/^0\.0[1-9]/), @tester.decimal(1,2)
+        assert_match (/^0\.0[1-9]/), @tester.decimal(whole_digits: 1, decimal_digits: 2)
       end
     end
   end

--- a/test/test_faker_street.rb
+++ b/test/test_faker_street.rb
@@ -39,7 +39,7 @@ class TestFakerStreet < Test::Unit::TestCase
 
   def test_street_address_optionally_provides_secondary_address
     I18n.with_locale(:shire) do
-      assert_match(/Wide Cheerful Path \d \(Green Door\)/, Faker::Address.street_address(:include_secondary))
+      assert_match(/Wide Cheerful Path \d \(Green Door\)/, Faker::Address.street_address(include_secondary: true))
     end
   end
 

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -13,7 +13,7 @@ class TestFakerTime < Test::Unit::TestCase
     to   = Time.at(2145945600)
 
     100.times do
-      random_time = @tester.between(from, to)
+      random_time = @tester.between(from: from, to: to)
       assert random_time >= from, "Expected >= \"#{from}\", but got #{random_time}"
       assert random_time <= to  , "Expected <= \"#{to}\", but got #{random_time}"
     end
@@ -24,7 +24,7 @@ class TestFakerTime < Test::Unit::TestCase
     to   = Time.at(2145945600).to_date
 
     100.times do
-      random_time = @tester.between(from, to)
+      random_time = @tester.between(from: from, to: to)
       assert random_time.to_date >= from, "Expected >= \"#{from}\", but got #{random_time}"
       assert random_time.to_date <= to  , "Expected <= \"#{to}\", but got #{random_time}"
     end
@@ -34,7 +34,7 @@ class TestFakerTime < Test::Unit::TestCase
     today = Date.today
 
     100.times do
-      random_time = @tester.forward(10)
+      random_time = @tester.forward(days: 10)
       assert random_time > today.to_time, "Expected > \"#{today}\", but got #{random_time}"
     end
   end
@@ -43,7 +43,7 @@ class TestFakerTime < Test::Unit::TestCase
     tomorrow = Date.today + 1
 
     100.times do
-      random_time = @tester.backward(10)
+      random_time = @tester.backward(days: 10)
       assert random_time < tomorrow.to_time, "Expected < \"#{tomorrow}\", but got #{random_time}"
     end
   end
@@ -53,15 +53,15 @@ class TestFakerTime < Test::Unit::TestCase
     to   = Date.today + 15
 
     assert_raise ArgumentError do
-      @tester.between(from, to, :invalid_period)
+      @tester.between(from: from, to: to, period: :invalid_period)
     end
   end
 
   def test_return_type
-    random_backward = @tester.backward(5)
-    random_between_dates = @tester.between(Date.today, Date.today + 5)
-    random_between_times = @tester.between(Time.now, Time.now + TEN_HOURS)
-    random_forward  = @tester.forward(5)
+    random_backward = @tester.backward(days: 5)
+    random_between_dates = @tester.between(from: Date.today, to: Date.today + 5)
+    random_between_times = @tester.between(from: Time.now, to: Time.now + TEN_HOURS)
+    random_forward  = @tester.forward(days: 5)
 
     [
       random_backward,
@@ -81,9 +81,9 @@ class TestFakerTime < Test::Unit::TestCase
       period          = @time_ranges.keys.to_a.sample
       period_range    = @time_ranges[period]
 
-      random_backward = @tester.backward(30, period)
-      random_between  = @tester.between(from, to, period)
-      random_forward  = @tester.forward(30, period)
+      random_backward = @tester.backward(days: 30, period: period)
+      random_between  = @tester.between(from: from, to: to, period: period)
+      random_forward  = @tester.forward(days: 30, period: period)
 
       [random_backward, random_between, random_forward].each_with_index do |result, index|
         assert period_range.include?(result.hour.to_i), "#{[:random_backward, :random_between, :random_forward][index]}: \"#{result}\" expected to be included in Faker::Time::TIME_RANGES[:#{period}] range"

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -90,4 +90,10 @@ class TestFakerTime < Test::Unit::TestCase
       end
     end
   end
+
+  def test_missing_required_args
+    assert_raise ArgumentError do
+      @tester.between
+    end
+  end
 end

--- a/test/test_placeholdit.rb
+++ b/test/test_placeholdit.rb
@@ -8,85 +8,84 @@ class TestPlaceholdit < Test::Unit::TestCase
   def test_placeholdit
     assert @tester.image.match(/https:\/\/placehold\.it\/(.+)(png?)/)[1] != nil
   end
-
   def test_avatar_with_custom_size
-    assert @tester.image('3x3').match(/https:\/\/placehold\.it\/+(\d+x\d+)/)[1] == '3x3'
+    assert @tester.image(size: '3x3').match(/https:\/\/placehold\.it\/+(\d+x\d+)/)[1] == '3x3'
   end
 
   def test_avatar_with_incorrect_size
     assert_raise ArgumentError do
-      @tester.image('300x300s')
+      @tester.image(size: '300x300s')
     end
   end
 
   def test_avatar_with_supported_format
-    assert @tester.image('300x300', 'jpg').match(/https:\/\/placehold\.it\/(.+)(jpg?)/)
+    assert @tester.image(size: '300x300', format: 'jpg').match(/https:\/\/placehold\.it\/(.+)(jpg?)/)
   end
 
   def test_avatar_with_incorrect_format
     assert_raise ArgumentError do
-      @tester.image('300x300', 'wrong_format')
+      @tester.image(size: '300x300', format: 'wrong_format')
     end
   end
 
   def test_avatar_background_with_correct_six_char_hex
-    assert @tester.image('300x300', 'jpg', 'ffffff').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff/)
   end
 
   def test_avatar_background_with_correct_three_char_hex
-    assert @tester.image('300x300', 'jpg', 'fff').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/fff/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/fff/)
   end
 
   def test_avatar_background_with_wrong_six_char_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'fffffz')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'fffffz')
     end
   end
 
   def test_avatar_background_with_wrong_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'ffff4')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'ffff4')
     end
   end
 
   def test_avatar_background_with_wrong_three_char_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'ffz')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'ffz')
     end
   end
 
   def test_avatar_font_color_with_correct_six_char_hex
-    assert @tester.image('300x300', 'jpg', 'ffffff', '000000').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff\/000000/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '000000').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/ffffff\/000000/)
   end
 
   def test_avatar_font_color_with_correct_three_char_hex
-    assert @tester.image('300x300', 'jpg', 'fff', '000').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/fff/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(/https:\/\/placehold\.it\/(.+)(jpg?)\/fff/)
   end
 
   def test_avatar_font_color_with_wrong_six_char_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'ffffff', '900F0z')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '900F0z')
     end
   end
 
   def test_avatar_font_color_with_wrong_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'ffffff', 'x9')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: 'x9')
     end
   end
 
   def test_avatar_font_color_with_wrong_three_char_hex
     assert_raise ArgumentError do
-      @tester.image('300x300', 'jpg', 'ffffff', '00p')
+      @tester.image(size: '300x300', format: 'jpg', background_color: 'ffffff', text_color: '00p')
     end
   end
 
   def test_text_not_present
-    assert @tester.image('300x300', 'jpg', 'fff', '000').match(/https:\/\/placehold\.it\/[^\\?]+$/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000').match(/https:\/\/placehold\.it\/[^\\?]+$/)
   end
 
   def test_text_present
-    assert @tester.image('300x300', 'jpg', 'fff', '000', 'hello').match(/https:\/\/placehold\.it\/(.+)\?text=hello/)
+    assert @tester.image(size: '300x300', format: 'jpg', background_color: 'fff', text_color: '000', text: 'hello').match(/https:\/\/placehold\.it\/(.+)\?text=hello/)
   end
 
 end


### PR DESCRIPTION
This would resolve #603.

The only two I didn't convert to kwargs was `Internet.fix_umlauts` and  `Lorem.characters` because those both have a single argument that seemed obvious. 

I also didn't touch `Finance` because there was no documentation or tests for it, so wasn't sure if it is even being used. I can open an issue for that if you want that added. Could probably throw some time towards that next week.
