### PR TITLE
Changed quotes in color.rb

### DIFF
--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -2,7 +2,7 @@ module Faker
   class Color < Base
     class << self
       def hex_color
-        @hex_color = "#%06x" % (rand * 0xffffff)
+        @hex_color = '#%06x' % (rand * 0xffffff)
       end
 
       def color_name


### PR DESCRIPTION
Hi. 

As this was not a string interpolation or special symbol, I switched double quotes to single quotes.

```bundle exec rake``` executed, all green. 

Thank you.