### PR TITLE
Add educational_email for .edu addresses

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -6,6 +6,10 @@ module Faker
         [user_name(name), domain_name].join('@')
       end
 
+      def educational_email(name = nil)
+        [user_name(name), [domain_name.split('.').first, 'edu'].join('.')].join('@')
+      end
+
       def free_email(name = nil)
         [user_name(name), fetch('internet.free_email')].join('@')
       end

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -10,6 +10,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.email.match(/.+@.+\.\w+/)
   end
 
+  def test_educational_email
+    assert @tester.educational_email.match(/.+\@.+\.edu/)
+  end
+
   def test_free_email
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end


### PR DESCRIPTION
Adds `Faker::Internet.educational_email` to generate emails that end with .edu.