### PR TITLE
Improved de-AT unit tests

### DIFF
--- a/test/test_de_at_locale.rb
+++ b/test/test_de_at_locale.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
 class TestDeAtLocale < Test::Unit::TestCase
@@ -14,6 +16,7 @@ class TestDeAtLocale < Test::Unit::TestCase
     assert Faker::Address.state.is_a? String
     assert Faker::Address.state_abbr.is_a? String
     assert Faker::Address.city_name.is_a? String
+    assert Faker::Address.street_root.is_a? String
     assert Faker::Company.suffix.is_a? String
     assert Faker::Company.name.is_a? String
     assert Faker::Internet.free_email.is_a? String
@@ -23,5 +26,9 @@ class TestDeAtLocale < Test::Unit::TestCase
     assert Faker::Name.prefix.is_a? String
     assert Faker::Name.nobility_title_prefix.is_a? String
     assert Faker::Name.name.is_a? String
+  end
+
+  def test_at_default_country
+    assert_equal('Österreich', Faker::Address.default_country)
   end
 end


### PR DESCRIPTION
Hi.

Improved ```test_de_at_locale.rb``` a bit.

1) The de-AT locale included special characters and utf-8 encoding was not in place. This has been now fixed. 

2) Improved missing unit test coverage on ```test_de_at_methods``` method. 

3) Implemented method to test default country.

```bundle exec rake``` executed locally - all green.

Thank you.