### PR TITLE
Remove Faker::ChuckNorris.name method

### DIFF
--- a/lib/faker/chuck_norris.rb
+++ b/lib/faker/chuck_norris.rb
@@ -3,11 +3,6 @@ module Faker
     flexible :name
 
     class << self
-
-      def name
-        parse('chuck_norris')
-      end
-
       # from: https://github.com/jenkinsci/chucknorris-plugin/blob/master/src/main/java/hudson/plugins/chucknorris/FactGenerator.java
       def fact; fetch('chuck_norris.fact'); end
 


### PR DESCRIPTION
* This method is not being implemented properly
* Module#name according to Ruby language spec (http://ruby-doc.org/core-2.3.1/Module.html#method-i-name) should return string (name of the module) or nil for anonymous class
* In case of our project it's causing Cucumber tests to fail at start (::Faker::ChuckNorris.name fails by itself and some of the gems are scanning whole object space with calling klass.name on every class found)