### PR TITLE
Fixed a method call in date.rb

### DIFF
--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -5,7 +5,7 @@ module Faker
         from = get_date_object(from)
         to   = get_date_object(to)
 
-        Faker::Base::rand_in_range(from, to)
+        Faker::Base.rand_in_range(from, to)
       end
 
       def between_except(from, to, excepted)


### PR DESCRIPTION
Hello. 

A call ```::``` should be used only to reference constants and constructors. 

This has been now fixed to use regular method call.

```bundle exec rake``` executed locally - all green.

Thank you. 