### PR TITLE
Adding ability to set URL scheme to Internet#url

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,11 @@ Faker::Internet.ip_v6_cidr #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df/78"
 Faker::Internet.mac_address #=> "e6:0d:00:11:ed:4f"
 Faker::Internet.mac_address('55:44:33') #=> "55:44:33:02:1d:9b"
 
-# Optional arguments: host=domain_name, path="/#{user_name}"
+# Keyword arguments: host=domain_name, path="/#{user_name}", scheme=http
 Faker::Internet.url #=> "http://thiel.com/chauncey_simonis"
-Faker::Internet.url('example.com') #=> "http://example.com/clotilde.swift"
-Faker::Internet.url('example.com', '/foobar.html') #=> "http://example.com/foobar.html"
+Faker::Internet.url(host: 'example.com') #=> "http://example.com/clotilde.swift"
+Faker::Internet.url(path: '/foobar.html') #=> "http://theil.com/foobar.html"
+Faker::Internet.url(scheme: 'https') #=> "https://theil.com/clotilde.swift"
 
 # Optional arguments: words=nil, glue=nil
 Faker::Internet.slug #=> "pariatur_laudantium"

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -145,9 +145,10 @@ module Faker
       end
 
       def url(host = domain_name, path = "/#{user_name}", **options)
+        scheme = options.fetch(:scheme, 'http')
         host = options.fetch(:host, host)
         path = options.fetch(:path, path)
-        "http://#{host}#{path}"
+        "#{scheme}://#{host}#{path}"
       end
 
       def slug(words = nil, glue = nil)

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -144,7 +144,9 @@ module Faker
         "#{ip_v6_address}/#{1 + rand(127)}"
       end
 
-      def url(host = domain_name, path = "/#{user_name}")
+      def url(host = domain_name, path = "/#{user_name}", **options)
+        host = options.fetch(:host, host)
+        path = options.fetch(:path, path)
         "http://#{host}#{path}"
       end
 

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -199,6 +199,14 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.url('domain.com', '/username').match(/^http:\/\/domain\.com\/username$/)
   end
 
+  def test_url_hash_paremeters
+    assert @tester.url(host: 'example.com', path: '/a_path').match(/^http:\/\/example\.com\/a_path$/)
+  end
+
+  def test_url_mixed_parameters
+    assert @tester.url('example.com', path: '/username').match(/^http:\/\/example\.com\/username/)
+  end
+
   def test_device_token
     assert_equal 64, @tester.device_token.size
   end

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -207,6 +207,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.url('example.com', path: '/username').match(/^http:\/\/example\.com\/username/)
   end
 
+  def test_url_https
+    assert @tester.url(scheme: 'https').match(/^https:\/\//)
+  end
+
   def test_device_token
     assert_equal 64, @tester.device_token.size
   end


### PR DESCRIPTION
Also adding support for keyword/hash arguments, since only specifying one
of domain/scheme/path seems like a reasonable thing to be able to do.

Use of double splat (**options) is ruby 2.0 only, but as other tests fail
on ruby 1.9.3 I expected the incompatibility to be ok.
