### PR TITLE
Added shorthand for self-assignment on date.rb

### DIFF
--- a/lib/faker/date.rb
+++ b/lib/faker/date.rb
@@ -60,8 +60,8 @@ module Faker
 
       def customized_bound(bound, increase = false)
         if (bound % 4) != 0
-          bound = bound + 1 if increase
-          bound = bound - 1 unless increase
+          bound += 1 if increase
+          bound -= 1 unless increase
           customized_bound(bound, increase)
         else
           bound


### PR DESCRIPTION
The self-assignment in ```lib/faker/date.rb``` was not using shorthand. This has now been fixed to improve the readability of source code.

```bundle exec rake``` executed locally, all green.

Thank you.