### PR TITLE
Fixed single-line method in chuck_norris.rb

### DIFF
--- a/lib/faker/chuck_norris.rb
+++ b/lib/faker/chuck_norris.rb
@@ -4,8 +4,9 @@ module Faker
 
     class << self
       # from: https://github.com/jenkinsci/chucknorris-plugin/blob/master/src/main/java/hudson/plugins/chucknorris/FactGenerator.java
-      def fact; fetch('chuck_norris.fact'); end
-
+      def fact
+        fetch('chuck_norris.fact')
+      end
     end
   end
 end


### PR DESCRIPTION
Hello.

Single-line methods should be avoided. There was one in ```lib/faker/chuck_norris.rb```. 

This has now been fixed. 

```bundle exec rake``` executed locally - all green.

Thank you.