### PR TITLE
Convert hashes to hash with indifferent access for rails

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -131,13 +131,21 @@ module Faker
         }.join
       end
 
+      def with_indifferent_access(values)
+        return values unless values.is_a?(Array)
+
+        values.map do |v|
+          v.respond_to?(:with_indifferent_access) ? v.with_indifferent_access : v
+        end
+      end
+
       # Call I18n.translate with our configured locale if no
       # locale is specified
       def translate(*args)
         opts = args.last.is_a?(Hash) ? args.pop : {}
         opts[:locale] ||= Faker::Config.locale
         opts[:raise] = true
-        I18n.translate(*(args.push(opts)))
+        with_indifferent_access(I18n.translate(*(args.push(opts))))
       rescue I18n::MissingTranslationData
         opts = args.last.is_a?(Hash) ? args.pop : {}
         opts[:locale] = :en
@@ -145,7 +153,7 @@ module Faker
         # Super-simple fallback -- fallback to en if the
         # translation was missing.  If the translation isn't
         # in en either, then it will raise again.
-        I18n.translate(*(args.push(opts)))
+        with_indifferent_access(I18n.translate(*(args.push(opts))))
       end
 
       # Executes block with given locale set.


### PR DESCRIPTION
Deals with symbol keys in hash when translating values with I18n (Issue #627). This PR converts the hash to a hash with indifferent access in order to support string or symbol access.

This problem only arises in rails console which converts the hash keys into symbol. Here's an example:

```
Rails console
2.3.0 :001 > I18n.translate(*["faker.vehicle.manufacture", {:locale=>:en, :raise=>true}]).first
 => {:name=>"MARQUESS ELECTRIC CAR COMPANY", :wmi=>"15E", :wmi_ext=>nil}

IRB console
2.3.0 :003 > I18n.translate(*["faker.vehicle.manufacture", {:locale=>:en, :raise=>true}]).first
 => {"name"=>"MARQUESS ELECTRIC CAR COMPANY", "wmi"=>"15E", "wmi_ext"=>nil}
```
