### PR TITLE
Added default country check to en-PAK unit tests

### DIFF
--- a/test/test_en_pak_locale.rb
+++ b/test/test_en_pak_locale.rb
@@ -21,6 +21,6 @@ class TestEnPakLocale < Test::Unit::TestCase
   end
 
   def test_en_pak_default_country
-    assert_includes 'Pakistan', Faker::Address.default_country
+    assert_match(/\A(Pakistan|Islamic Republic of Pakistan)\z/, Faker::Address.default_country)
   end
 end

--- a/test/test_en_pak_locale.rb
+++ b/test/test_en_pak_locale.rb
@@ -19,4 +19,8 @@ class TestEnPakLocale < Test::Unit::TestCase
     assert Faker::Internet.domain_suffix.is_a? String
     assert Faker::Company.suffix.is_a? String
   end
+
+  def test_en_pak_default_country
+    assert_includes 'Pakistan', Faker::Address.default_country
+  end
 end


### PR DESCRIPTION
Added unit test which checks that default country includes substring "Pakistan" in ```en-PAK``` locale.

```bundle exec rake``` executed - all green.

Thank you.