### PR TITLE
Fixed incorrect locale configuration

### DIFF
--- a/test/test_de_ch_locale.rb
+++ b/test/test_de_ch_locale.rb
@@ -1,8 +1,8 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TestDeAtLocale < Test::Unit::TestCase
+class TestDeChLocale < Test::Unit::TestCase
   def setup
-    Faker::Config.locale = 'de-AT'
+    Faker::Config.locale = 'de-CH'
   end
 
   def teardown


### PR DESCRIPTION
Hi.

Looks like ```de-CH``` locale was configured to use ```de-AT``` as a source.

This has now been amended.

```bundle exec rake``` executed locally - all green.

Thank you.