### PR TITLE
Added default country test to en-AU locale

### DIFF
--- a/test/test_en_au_locale.rb
+++ b/test/test_en_au_locale.rb
@@ -20,6 +20,10 @@ class TestEnAuLocale < Test::Unit::TestCase
     assert Faker::Address.default_country.is_a? String
   end
 
+  def test_en_au_default_country
+    assert_equal 'Australia', Faker::Address.default_country
+  end
+
   def test_aussie_mobiles_start_with_04
     mobile = Faker::PhoneNumber.cell_phone.gsub(/\D/,'')
     assert_equal '0', mobile[0]


### PR DESCRIPTION
Hello.

```en-AU``` locale was missing a method to test the default country.

This has been now added.

```bundle exec rake``` executed locally - all green.

Thank you.