### PR TITLE
Fix for memory overflow error Issue: #478

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -19,14 +19,14 @@ module Faker
           if specifier.kind_of? String
             return specifier.scan(/\w+/).shuffle.join(separators.sample).downcase
           elsif specifier.kind_of? Integer
+            # If specifier is Integer and has large value, Argument error exception is raised to overcome memory full error 
+            raise ArgumentError, "Given argument is too large" if specifier > 10**6
             tries = 0 # Don't try forever in case we get something like 1_000_000.
             begin
               result = user_name nil, separators
               tries += 1
             end while result.length < specifier and tries < 7
-            until result.length >= specifier
-              result = result * 2
-            end
+            result = result * (specifier/result.length + 1) if specifier > 0
             return result
           elsif specifier.kind_of? Range
             tries = 0

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -31,6 +31,11 @@ class TestFakerInternet < Test::Unit::TestCase
       assert @tester.user_name(min_length).length >= min_length
     end
   end
+  
+  def test_user_name_with_very_large_integer_arg
+    exception = assert_raises(ArgumentError) { @tester.user_name(10000000) }
+    assert_equal('Given argument is too large', exception.message)
+  end
 
   def test_user_name_with_closed_range_arg
     (1..32).each do |min_length|


### PR DESCRIPTION
 Issue: #478 
+ Raises argument error if a large integer argument is passed
+ Optimises calculation of result string