### PR TITLE
add Faker::Commerce.promotion_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Faker::Commerce.product_name #=> "Practical Granite Shirt"
 
 Faker::Commerce.price #=> "44.6"
 
+# Generate a random promotion code.
+# Optional argument digits = 6 for number of random digits in suffix
+Faker::Commerce.promotion_code #=> "AmazingDeal829102"
+
 ```
 
 ###Faker::Company

--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -6,6 +6,14 @@ module Faker
         fetch('color.name')
       end
 
+      def promotion_code(digits = 6)
+        [
+          fetch('commerce.promotion_code.adjective'),
+          fetch('commerce.promotion_code.noun'),
+          Faker::Number.number(digits)
+        ].join
+      end
+
       def department(max = 3, fixed_amount = false)
         num = max if fixed_amount
         num ||= 1 + rand(max)

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -157,6 +157,9 @@ en:
         adjective: [Small, Ergonomic, Rustic, Intelligent, Gorgeous, Incredible, Fantastic, Practical, Sleek, Awesome, Enormous, Mediocre, Synergistic, Heavy Duty, Lightweight, Aerodynamic, Durable]
         material: [Steel, Wooden, Concrete, Plastic, Cotton, Granite, Rubber, Leather, Silk, Wool, Linen, Marble, Iron, Bronze, Copper, Aluminum, Paper]
         product: [Chair, Car, Computer, Gloves, Pants, Shirt, Table, Shoes, Hat, Plate, Knife, Bottle, Coat, Lamp, Keyboard, Bag, Bench, Clock, Watch, Wallet]
+      promotion_code:
+        adjective: ['Amazing', 'Awesome', 'Cool', 'Good', 'Great', 'Incredible', 'Killer', 'Premium', 'Special', 'Stellar', 'Sweet']
+        noun: ['Code', 'Deal', 'Discount', 'Price', 'Promo', 'Promotion', 'Sale', 'Savings']
 
     team:
       creature: ['ants', 'bats', 'bears', 'bees', 'birds', 'buffalo', 'cats', 'chickens', 'cattle', 'dogs', 'dolphins', 'ducks', 'elephants', 'fishes', 'foxes', 'frogs', 'geese', 'goats', 'horses', 'kangaroos', 'lions', 'monkeys', 'owls', 'oxen', 'penguins', 'people', 'pigs', 'rabbits', 'sheep', 'tigers', 'whales', 'wolves', 'zebras', 'banshees', 'crows', 'black cats', 'chimeras', 'ghosts', 'conspirators', 'dragons', 'dwarves', 'elves', 'enchanters', 'exorcists', 'sons', 'foes', 'giants', 'gnomes', 'goblins', 'gooses', 'griffins', 'lycanthropes', 'nemesis', 'ogres', 'oracles', 'prophets', 'sorcerors', 'spiders', 'spirits', 'vampires', 'warlocks', 'vixens', 'werewolves', 'witches', 'worshipers', 'zombies', 'druids']

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -10,6 +10,14 @@ class TestFakerCommerce < Test::Unit::TestCase
     assert @tester.color.match(/[a-z]+\.?/)
   end
 
+  def test_promotion_code
+    assert @tester.promotion_code.match(/[A-Z][a-z]+[A-Z][a-z]+\d{6}/)
+  end
+
+  def test_promotion_code_should_have_specified_number_of_digits
+    assert @tester.promotion_code(3).match(/[A-Z][a-z]+[A-Z][a-z]+\d{3}/)
+  end
+
   def test_department
     assert @tester.department.match(/[A-Z][a-z]+\.?/)
   end


### PR DESCRIPTION
Adds a **promotion_code** method to the `Faker::Commerce` class. This is not only useful for test data but also for randomly generated promotion codes for e-commerce.