### PR TITLE
Add password_confirmation method to Faker::Internet

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -2,6 +2,8 @@
 module Faker
   class Internet < Base
     class << self
+      @@password = nil
+
       def email(name = nil)
         [user_name(name), domain_name].join('@')
       end
@@ -68,7 +70,13 @@ module Faker
           end
         end
 
-        return temp
+        @@password = temp
+
+        return @@password
+      end
+
+      def password_confirmation
+        return @@password
       end
 
       def domain_name


### PR DESCRIPTION
A simple way to use the same password generated from Faker::Internet.password method. Great to  create objects from models with validation of password confirmation.