### PR TITLE
allow Time.between to receive `:between` to deliver time in range

### DIFF
--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -12,7 +12,11 @@ module Faker
 
     class << self
       def between(from, to, period = :all)
-        date_with_random_time(super(from, to), period)
+        if period == :between
+          rand(from..to)
+        else
+          date_with_random_time(super(from, to), period)
+        end
       end
 
       def forward(days = 365, period = :all)

--- a/test/test_faker_time.rb
+++ b/test/test_faker_time.rb
@@ -89,5 +89,15 @@ class TestFakerTime < Test::Unit::TestCase
         assert period_range.include?(result.hour.to_i), "#{[:random_backward, :random_between, :random_forward][index]}: \"#{result}\" expected to be included in Faker::Time::TIME_RANGES[:#{period}] range"
       end
     end
+
+    from = Time.now
+    to   = Time.now + 100
+
+    100.times do
+      period          = :between
+      random_between  = @tester.between(from, to, period)
+      assert random_between >= from, "Expected >= \"#{from}\", but got #{random_between}"
+      assert random_between <= to  , "Expected <= \"#{to}\", but got #{random_between}"
+    end
   end
 end


### PR DESCRIPTION
I'd even say that this should be the default instead of `:all`, but it might be a breaking change for others so I implemented it like this.
