### PR TITLE
Improve Address.postcode example to reflect actual output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Faker::Address.zip_code #=> "58517"
 
 Faker::Address.zip #=> "58517"
 
-Faker::Address.postcode #=> "58517"
+Faker::Address.postcode #=> "76032-4907" or "58517"
 
 Faker::Address.time_zone #=> "Asia/Yakutsk"
 


### PR DESCRIPTION
Some of my tests did not pass when the generated postcodes were of the `12345-1234` format instead of `12345`. 
I'm now using `Faker::Address.zip` instead, but having the documentation warn that the output format of `Address.postcode` can vary would have prevented that problem in the first place.
