### PR TITLE
fixed typo in secondary_school

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ Faker::ChuckNorris.fact #=> "Chuck Norris can solve the Towers of Hanoi in one m
 ```ruby
 Faker::Educator.university #=> "Mallowtown Technical College"
 
-Faker::Educator.secondary_school #=> "Iceborough Secodary College"
+Faker::Educator.secondary_school #=> "Iceborough Secondary College"
 
 Faker::Educator.course #=> "Associate Degree in Criminology"
 

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -241,7 +241,7 @@ en:
 
     educator:
       name: ['Marblewald', 'Mallowtown', 'Brookville', 'Flowerlake', 'Falconholt', 'Ostbarrow', 'Lakeacre', 'Clearcourt', 'Ironston', 'Mallowpond', 'Iceborough', 'Icelyn', 'Brighthurst', 'Bluemeadow', 'Vertapple', 'Ironbarrow']
-      secondary: ['High School', 'Secodary College', 'High']
+      secondary: ['High School', 'Secondary College', 'High']
       tertiary:
         type: ['College', 'University', 'Technical College', 'TAFE']
         course:


### PR DESCRIPTION
It now read `secodary` instead of `secondary`.  This fix also fixes the typo in the README.
