### PR TITLE
Changed quotes in food.rb

### DIFF
--- a/lib/faker/food.rb
+++ b/lib/faker/food.rb
@@ -10,7 +10,7 @@ module Faker
       end
 
       def measurement
-        fetch('food.measurement_sizes') + " " + fetch('food.measurements')
+        fetch('food.measurement_sizes') + ' ' + fetch('food.measurements')
       end
     end
   end


### PR DESCRIPTION
Hello.

Just a quick one in lib/faker/food.rb: double-quotes are needed only when dealing with interpolation. Hence, I changed the quotes in measurement method to single quotes.

`bundle exec rake` executed locally - all green.

Thank you. 
