### PR TITLE
Fixed the inaccurate swedish organization number generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Faker::Company.duns_number #=> "08-341-3736"
 # Get a random company logo url in PNG format.
 Faker::Company.logo #=> "https://pigment.github.com/fake-logos/logos/medium/color/5.png"
 
-Faker::Company.swedish_organisation_number #=> "7718797652"
+Faker::Company.swedish_organisation_number #=> "7962578022"
 
 # Generate an Australian Business Number
 Faker::Company.australian_business_number #=> "81137773602"

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -43,8 +43,12 @@ module Faker
         "https://pigment.github.io/fake-logos/logos/medium/color/#{rand_num}.png"
       end
 
+      # Get a random Swedish organization number. See more here https://sv.wikipedia.org/wiki/Organisationsnummer
       def swedish_organisation_number
-        base = ('%09d' % rand(10 ** 9))
+        # Valid leading digit: 1, 2, 3, 5, 6, 7, 8, 9
+        # Valid third digit: >= 2
+        # Last digit is a control digit
+        base = [[1, 2, 3, 5, 6, 7, 8, 9].sample, (0..9).to_a.sample, (2..9).to_a.sample, ('%06d' % rand(10 ** 6))].join
         base + luhn_algorithm(base).to_s
       end
 

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -24,6 +24,8 @@ class TestFakerCompany < Test::Unit::TestCase
   def test_swedish_organisation_number
     org_no = @tester.swedish_organisation_number
     assert org_no.match(/\d{10}/)
+    assert [1, 2, 3, 5, 6, 7, 8, 9].include?(org_no[0].to_i)
+    assert org_no[2].to_i >= 2
     assert org_no[9] == @tester.send(:luhn_algorithm, org_no[0..8]).to_s
   end
 


### PR DESCRIPTION
A valid Swedish organization number has the following restrictions:
- first digit: one of 1, 2, 3, 5, 6, 7, 8, 9
- the third digit: >= 2
- last digit is a control digit

More information can be found at https://sv.wikipedia.org/wiki/Organisationsnummer. There is also an number validator: http://www.stenborg.se/nytta/kontrollera_personnummer_och_organisationsnummer.htm
