### PR TITLE
Resolve warnings during tests

### DIFF
--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -77,9 +77,9 @@ module Faker
 
         # Calculate the Luhn checksum of the values thus far
         len_offset = (len + 1) % 2
-        (0..(len - 1)).each do |pos|
-          if (pos + len_offset) % 2 != 0
-            t = str[pos] * 2
+        (0..(len - 1)).each do |position|
+          if (position + len_offset) % 2 != 0
+            t = str[position] * 2
 
             if t > 9
               t -= 9
@@ -87,7 +87,7 @@ module Faker
 
             sum += t
           else
-            sum += str[pos]
+            sum += str[position]
           end
         end
 

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -69,8 +69,8 @@ module Faker
             multiplications << digit.to_i * 2
           else
             multiplications << digit.to_i
+          end
         end
-      end
 
         sum = 0
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require 'test/unit'
 require 'rubygems'
 require 'timecop'
 require 'yaml'
-YAML::ENGINE.yamler = 'syck' if defined? YAML::ENGINE
+YAML::ENGINE.yamler = 'psych' if defined? YAML::ENGINE
 require File.expand_path(File.dirname(__FILE__) + '/../lib/faker')
 
 # configure I18n


### PR DESCRIPTION
I was getting two warnings runnings tests:

```
/Users/andy/faker/lib/faker/code.rb:80: warning: shadowing outer local variable - pos
/Users/andy/faker/lib/faker/company.rb:72: warning: mismatched indentations at 'end' with 'if' at 68
```

This resolves them.
