### PR TITLE
Add Normal (Gaussian) distribution to Faker::Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ Faker::Number.decimal(2) #=> "11.88"
 
 Faker::Number.decimal(2, 3) #=> "18.843"
 
+# Required parameters: mean, standard_deviation
+Faker::Number.normal(50, 3.5) #=> 47.14669604069156
+
 # Required parameter: digits
 Faker::Number.hexadecimal(3) #=> "e74"
 

--- a/lib/faker/number.rb
+++ b/lib/faker/number.rb
@@ -43,6 +43,13 @@ module Faker
         hex
       end
 
+      def normal(mean, standard_deviation)
+        theta = 2 * Math::PI * rand
+        rho = Math.sqrt(-2 * Math.log(1 - rand))
+        scale = standard_deviation * rho
+        mean + scale * Math.cos(theta)
+      end
+
       def between(from = 1.00, to = 5000.00)
         Faker::Base::rand_in_range(from, to)
       end

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -44,6 +44,17 @@ class TestFakerNumber < Test::Unit::TestCase
     end
   end
 
+  def test_normal
+    n = 10000
+    values = n.times.map { @tester.normal 150, 100 }
+    mean = values.reduce(:+) / n.to_f
+    variance = values.inject(0) { |variance, value| variance + (value - mean) ** 2 } / (n-1).to_f
+    std_dev = Math.sqrt variance
+
+    assert_in_delta 150.0, mean, 5
+    assert_in_delta 100.0, std_dev, 5
+  end
+
   def test_between
     100.times do
       random_number = @tester.between(-50, 50)

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -51,8 +51,8 @@ class TestFakerNumber < Test::Unit::TestCase
     variance = values.inject(0) { |variance, value| variance + (value - mean) ** 2 } / (n-1).to_f
     std_dev = Math.sqrt variance
 
-    assert_in_delta 150.0, mean, 5
-    assert_in_delta 100.0, std_dev, 5
+    assert_in_delta 150.0, mean, 5.0
+    assert_in_delta 100.0, std_dev, 3.0
   end
 
   def test_between

--- a/test/test_faker_number.rb
+++ b/test/test_faker_number.rb
@@ -46,9 +46,9 @@ class TestFakerNumber < Test::Unit::TestCase
 
   def test_normal
     n = 10000
-    values = n.times.map { @tester.normal 150, 100 }
+    values = n.times.map { @tester.normal(150.0, 100.0) }
     mean = values.reduce(:+) / n.to_f
-    variance = values.inject(0) { |variance, value| variance + (value - mean) ** 2 } / (n-1).to_f
+    variance = values.inject(0) { |variance, value| variance + (value - mean) ** 2 } / (n - 1).to_f
     std_dev = Math.sqrt variance
 
     assert_in_delta 150.0, mean, 5.0


### PR DESCRIPTION
Added a generator for floats that are normally distributed around some given mean and standard deviation. Uses the [Box-Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform). Included test and updated README.

Not sure if `normal` is the best method name. If y'all would prefer something else (e.g. `gaussian`), let me know.
