### PR TITLE
fix german university name generation

### DIFF
--- a/lib/locales/de.yml
+++ b/lib/locales/de.yml
@@ -80,8 +80,8 @@ de:
       suffix: [Universität, Hochschule]
       name:
         - "#{Name.last_name} #{University.suffix}"
-        - "#{University.prefix} #{University.suffix} #{City.name}"
-        - "#{University.suffix} #{City.name}"
+        - "#{University.prefix} #{University.suffix} #{Address.city}"
+        - "#{University.suffix} #{Address.city}"
 
     # source: http://www.roundhousekick.de/top-100-chuck-norris-facts/
     chuck_norris:


### PR DESCRIPTION
`City.name` does not exist, so use `Address.city` instead.
