### PR TITLE
Add optional https urls

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -144,8 +144,8 @@ module Faker
         "#{ip_v6_address}/#{1 + rand(127)}"
       end
 
-      def url(host = domain_name, path = "/#{user_name}")
-        "http://#{host}#{path}"
+      def url(host = domain_name, path = "/#{user_name}", scheme = 'http')
+        "#{scheme}://#{host}#{path}"
       end
 
       def slug(words = nil, glue = nil)

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -201,7 +201,7 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_url
-    assert @tester.url('domain.com', '/username').match(/^http:\/\/domain\.com\/username$/)
+    assert @tester.url('domain.com', '/username', 'https').match(/^https:\/\/domain\.com\/username$/)
   end
 
   def test_device_token


### PR DESCRIPTION
Revisiting https://github.com/stympy/faker/pull/460

Adds optional scheme support to `Faker::Internet.url` in a backwards-compatible way.

🐙 