### PR TITLE
Delete unneeded line for Faker::Internet.password

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -53,7 +53,6 @@ module Faker
           diff_rand = rand(diff_length + 1)
           temp += Lorem.characters(diff_rand)
         end
-        temp = temp[0..min_length] if min_length > 0
 
         if mix_case
           temp.chars.each_with_index do |char, index|


### PR DESCRIPTION
There is a bug in `Faker::Internet.password`.

`#password` method receives `min_length` and `max_length` parameters.
But `max_length` is disabled and password length is forced to `min_length` because of this line.
```
temp = temp[0..min_length] if min_length > 0
```

After deleted this line, generated password length become random. And all tests have passed.

It is difficult to add test about this issue because of randomness.