### PR TITLE
Correct HSL and HSLA color formatting

### DIFF
--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -22,36 +22,18 @@ module Faker
         @rgb_colors
       end
 
-      def single_hsl_color
-        hsl_hue
-      end
-
-      def alpha_channel
-        rand.round(2)
-      end
-
       def hsl_color
-        hsl_colors = []
-        hsl_colors << hsl_hue
-        2.times { hsl_colors << rand.round(2) }
-        hsl_colors
+        hsl_values = []
+        hsl_values << (0..360).to_a.sample
+        2.times { hsl_values << rand.round(2) }
+        hsl_values
       end
 
       def hsla_color
-        @hsla_colors = []
-        3.times do
-          @hsla_colors.push single_hsl_color
-        end
-        @hsla_colors.push alpha_channel
-        @hsla_colors
+        hsla_values = hsl_color
+        hsla_values << rand.round(1)
+        hsla_values
       end
-
-      private
-
-      def hsl_hue
-        Faker::Base::rand_in_range(0, 360)
-      end
-
     end
   end
 end

--- a/lib/faker/color.rb
+++ b/lib/faker/color.rb
@@ -23,21 +23,18 @@ module Faker
       end
 
       def single_hsl_color
-        @single_hsla_color = Faker::Base::rand_in_range(0.0, 360.00).round(2)
-        @single_hsla_color
+        hsl_hue
       end
 
       def alpha_channel
-        @alpha_channel = rand
-        @alpha_channel
+        rand.round(2)
       end
 
       def hsl_color
-        @hsl_colors = []
-        3.times do
-          @hsl_colors.push single_hsl_color
-        end
-        @hsl_colors
+        hsl_colors = []
+        hsl_colors << hsl_hue
+        2.times { hsl_colors << rand.round(2) }
+        hsl_colors
       end
 
       def hsla_color
@@ -48,6 +45,13 @@ module Faker
         @hsla_colors.push alpha_channel
         @hsla_colors
       end
+
+      private
+
+      def hsl_hue
+        Faker::Base::rand_in_range(0, 360)
+      end
+
     end
   end
 end

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -26,17 +26,15 @@ class TestFakerColor < Test::Unit::TestCase
     end
   end
 
-  def test_single_hsl_color
-    assert @tester.single_hsl_color.between?(0.0, 360.0)
-  end
-
   def test_hsl_color
     @result = @tester.hsl_color
     assert @result.length == 3
 
-    @result.each do |color|
-      assert color.between?(0.0, 360.0)
-    end
+    assert @result[0].between?(0, 360)
+    assert @result[0].is_a?(Fixnum)
+
+    assert @result[1].between?(0.0, 1.0)
+    assert @result[2].between?(0.0, 1.0)
   end
 
   def test_hsla_color

--- a/test/test_faker_color.rb
+++ b/test/test_faker_color.rb
@@ -41,8 +41,9 @@ class TestFakerColor < Test::Unit::TestCase
     @result = @tester.hsla_color
     assert @result.length == 4
 
-    @result.each do |color|
-      assert color.between?(0.0, 360.0) || color.between?(0.0, 1.0)
-    end
+    assert @result[0].between?(0, 360)
+    assert @result[1].between?(0.0, 1.0)
+    assert @result[2].between?(0.0, 1.0)
+    assert @result[3].between?(0.0, 1.0)
   end
 end


### PR DESCRIPTION
In reference to issue #728, this is a correction of the formatting for Faker::Color.hsl_color and Faker::Color.hsls_color methods.