### PR TITLE
Frozen mutable objects in code.rb

### DIFF
--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -128,8 +128,8 @@ module Faker
         values << (check_digit == 10 ? 0 : check_digit).to_s
       end
 
-      EAN_CHECK_DIGIT8 = [3, 1, 3, 1, 3, 1, 3]
-      EAN_CHECK_DIGIT13 = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
+      EAN_CHECK_DIGIT8 = [3, 1, 3, 1, 3, 1, 3].freeze
+      EAN_CHECK_DIGIT13 = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3].freeze
 
       def rut_verificator_digit(rut)
         total = rut.to_s.rjust(8, '0').split(//).zip(%w(3 2 7 6 5 4 3 2)).collect{|a, b| a.to_i * b.to_i}.inject(:+)


### PR DESCRIPTION
Hi. 

Mutable objects assigned to constants should be frozen.

This has been now amended.

```bundle exec rake``` executed locally - all green.

Thank you.