### PR TITLE
Modify Faker::Educator, Fix #576

### DIFF
--- a/doc/educator.md
+++ b/doc/educator.md
@@ -7,7 +7,12 @@ Faker::Educator.university #=> "Mallowtown Technical College"
 
 Faker::Educator.secondary_school #=> "Iceborough Secondary College"
 
-Faker::Educator.course #=> "Associate Degree in Criminology"
+# [DEPRECATION] `course` is deprecated. Please use `degree` instead.
+Faker::Educator.degree #=> "Associate Degree in Criminology"
+
+Faker::Educator.course_name #=> "Criminology 101"
+
+Faker::Educator.subject #=> "Criminology"
 
 Faker::Educator.campus #=> "Vertapple Campus"
 ```

--- a/lib/faker/educator.rb
+++ b/lib/faker/educator.rb
@@ -3,12 +3,25 @@ module Faker
     flexible :educator
 
     class << self
+      extend Gem::Deprecate
+
       def university
         "#{parse('educator.name')} #{fetch('educator.tertiary.type')}"
       end
 
-      def course
-        "#{fetch('educator.tertiary.course.type')} #{fetch('educator.tertiary.course.subject')}"
+      def degree
+        "#{fetch('educator.tertiary.degree.type')} #{fetch('educator.tertiary.degree.subject')}"
+      end
+
+      alias course degree
+      deprecate :course, :course_name, 2018, 7
+
+      def subject
+        fetch('educator.tertiary.degree.subject').to_s
+      end
+
+      def course_name
+        "#{fetch('educator.tertiary.degree.subject')} #{numerify(fetch('educator.tertiary.degree.course_number'))}"
       end
 
       def secondary_school

--- a/lib/faker/educator.rb
+++ b/lib/faker/educator.rb
@@ -17,7 +17,7 @@ module Faker
       deprecate :course, :course_name, 2018, 10
 
       def subject
-        fetch('educator.tertiary.degree.subject').to_s
+        fetch('educator.tertiary.degree.subject')
       end
 
       def course_name

--- a/lib/faker/educator.rb
+++ b/lib/faker/educator.rb
@@ -14,7 +14,7 @@ module Faker
       end
 
       alias course degree
-      deprecate :course, :course_name, 2018, 7
+      deprecate :course, :course_name, 2018, 10
 
       def subject
         fetch('educator.tertiary.degree.subject').to_s

--- a/lib/locales/en/educator.yml
+++ b/lib/locales/en/educator.yml
@@ -5,6 +5,7 @@ en:
       secondary: ['High School', 'Secondary College', 'High']
       tertiary:
         type: ['College', 'University', 'Technical College', 'TAFE']
-        course:
+        degree:
           subject: ['Arts', 'Business', 'Education', 'Applied Science (Psychology)', 'Architectural Technology', 'Biological Science', 'Biomedical Science', 'Commerce', 'Communications', 'Creative Arts', 'Criminology', 'Design', 'Engineering', 'Forensic Science', 'Health Science', 'Information Systems', 'Computer Science', 'Law', 'Nursing', 'Medicine', 'Psychology', 'Teaching']
           type: ['Associate Degree in', 'Bachelor of', 'Master of']
+          course_number: ['1##', '2##', '3##', '4##', '5##']

--- a/test/test_faker_educator.rb
+++ b/test/test_faker_educator.rb
@@ -9,8 +9,16 @@ class TestFakerEducator < Test::Unit::TestCase
     assert @tester.university.match(/(\w+\.? ?){2,3}/)
   end
 
-  def test_course
-    assert @tester.university.match(/(\w+\.? ?){3,6}/)
+  def test_degree
+    assert @tester.degree.match(/(\w+\.? ?\(?\)?){3,6}/)
+  end
+
+  def test_subject
+    assert @tester.subject.match(/(\w+\.? ?\(?\)?){1,3}/)
+  end
+
+  def test_course_name
+    assert @tester.course_name.match(/(\w+\.? ?\(?\)?){1,3} \d{3}/)
   end
 
   def test_secondary_school


### PR DESCRIPTION
Hello. This PR is about fixing the issue #576 by adding a method 'subject'. Additionally I have edited the `Faker::Educator.course` method. Because the existing `course` method returns a string like "Associate Degree in Criminology". I think this is **a name of degree, not a name of course**. So I have renamed the `course` method to the `degree` method. Then I have created the new `course` method that returns something like "Criminology 201".

1. Created `subject` method that returns something like "Criminology", "Engineering", "Business"...
2. Renamed `course` method to `degree` method
3. Created `course` method that returns something like "Criminology 201", "Engineering 411", "Business 157"...

The tests for these changes have been added and all have passed. The documentation(faker/doc/educator.md) has updated for these changes.