### PR TITLE
Modify Faker::Commerce.price, Fix #806

### DIFF
--- a/lib/faker/commerce.rb
+++ b/lib/faker/commerce.rb
@@ -37,7 +37,7 @@ module Faker
         price = (random.rand(range) * 100).floor/100.0
         if as_string
           price_parts = price.to_s.split('.')
-          price = price_parts[0] + price_parts[-1].ljust(2, "0")
+          price = price_parts[0] + '.' + price_parts[-1].ljust(2, "0")
         end
         price
       end

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -89,4 +89,9 @@ class TestFakerCommerce < Test::Unit::TestCase
   def test_price_is_float
     assert @tester.price.is_a? Float
   end
+
+  def test_when_as_string_is_true
+    assert @tester.price(0..100.0, true).is_a?(String)
+    assert @tester.price(100..500.0, true).include?('.')
+  end
 end


### PR DESCRIPTION
Hello. This PR is about fixing the issue #806 by fixing the `Faker::Commerce.price` method. Because the existing `price` method returns an integer in a string format, instead of a float in a string format.

```bash
# Before
Faker::Commerce.price(50..100.0, true)
=> "8360"

# After
Faker::Commerce.price(50..100.0, true)
=> "83.60"
```

I added tests for this and they have passed. 

Thank you. :)