### PR TITLE
Allow unique values to be cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ Prefix your method call with `unique`. For example:
 Faker::Name.unique.name # This will return a unique name every time it is called
 ```
 
+If too many unique values are requested from a generator that has a limited
+number of potential values, a `Faker::UniqueGenerator::RetryLimitExceeded`
+exception may be raised. It is possible to clear the record of unique values
+that have been returned, for example between tests.
+```ruby
+Faker::Name.unique.clear # Clears used values for Faker::Name
+Faker::UniqueGenerator.clear # Clears used values for all generators
+```
+
 ## Customization
 
 Since you may want to make addresses and other types of data look different

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -26,7 +26,7 @@ module Faker
     end
 
     def self.clear
-      ObjectSpace.each_object(self) { |generator| generator.clear }
+      ObjectSpace.each_object(self, &:clear)
     end
   end
 end

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -20,5 +20,13 @@ module Faker
     end
 
     RetryLimitExceeded = Class.new(StandardError)
+
+    def clear
+      @previous_results.clear
+    end
+
+    def self.clear
+      ObjectSpace.each_object(self) { |generator| generator.clear }
+    end
   end
 end

--- a/test/test_faker_unique_generator.rb
+++ b/test/test_faker_unique_generator.rb
@@ -24,4 +24,30 @@ class TestFakerUniqueGenerator < Test::Unit::TestCase
     end
   end
 
+  def test_clears_unique_values
+    stubbed_generator = Object.new
+    def stubbed_generator.test
+      1
+    end
+
+    generator = Faker::UniqueGenerator.new(stubbed_generator, 3)
+
+    assert_equal(1, generator.test)
+
+    assert_raises Faker::UniqueGenerator::RetryLimitExceeded do
+      generator.test
+    end
+
+    Faker::UniqueGenerator.clear
+
+    assert_equal(1, generator.test)
+
+    assert_raises Faker::UniqueGenerator::RetryLimitExceeded do
+      generator.test
+    end
+
+    generator.clear
+
+    assert_equal(1, generator.test)
+  end
 end


### PR DESCRIPTION
We are using the `faker` gem in our project for testing, and while we require unique values, we only need them to be unique for each rspec example. By clearing the `previous_results` hash held by `Faker::UniqueGenerator` instances between tests, we significantly reduce the risk of running into `Faker::UniqueGenerator::RetryLimitExceeded` exceptions.

```ruby
RSpec.configure do |config|
  config.before do
    Faker::UniqueGenerator.clear
  end
end
```

We'd be happy to move or rename the method, or maybe we can simplify usage further by building specific integrations for different test frameworks.

What do you think?