### PR TITLE
Fix i18n file load issue

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -13,6 +13,7 @@ if I18n.respond_to?(:enforce_available_locales=)
   I18n.enforce_available_locales = true
 end
 I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
+I18n.reload!
 
 
 module Faker

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -13,7 +13,7 @@ if I18n.respond_to?(:enforce_available_locales=)
   I18n.enforce_available_locales = true
 end
 I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
-I18n.reload!
+I18n.reload! if I18n.backend.initialized?
 
 
 module Faker


### PR DESCRIPTION
Fixes https://github.com/stympy/faker/issues/278

First let me clarifying the steps to reproduce that issue.

In your Gemfile:
`gem 'faker', require: false`

In your console:
```
Loading development environment (Rails 5.0.1)
irb(main):001:0> I18n.backend.initialized?
=> false
irb(main):002:0> I18n.translate("doesn't matter just triggering a lookup")
=> "translation missing: en.doesn't matter just triggering a lookup"
irb(main):003:0> I18n.backend.initialized?
=> true
irb(main):004:0> require 'faker'
=> true
irb(main):005:0> Faker::Name.name
I18n::MissingTranslationData: translation missing: en.faker.name.name
	from /Users/jacknoble/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/i18n-0.7.0/lib/i18n.rb:311:in `handle_exception'
```

I18n loads files on the first lookup and once loaded doesn't load them again. See https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/simple.rb#L71. Adding Faker files to the load_path is not sufficient if I18n has already done a lookup.

Since this bug has to do with how the library is loaded I'm not sure how one might add a library test for it (Maybe Kernel.fork?)-- but I'm open to ideas if the owners feel a test is necessary.