### PR TITLE
Added area and exchange code features for en-CA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pkg/*
 .DS_Store
 
 .idea/*
+
+.ruby-*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,3 @@ DEPENDENCIES
   rake
   test-unit
   timecop
-
-BUNDLED WITH
-   1.14.5

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,11 @@ Dir['tasks/**/*.rake'].each { |rake| load rake }
 
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'faker' # You know what to do.
+  ARGV.clear
+  IRB.start
+end

--- a/doc/phone_number.md
+++ b/doc/phone_number.md
@@ -22,7 +22,7 @@ Faker::PhoneNumber.cell_phone #=> "(186)285-7925"
 # NOTE NOTE NOTE NOTE
 # For the 'US only' methods below, first you must do the following:
 Faker::Config.locale = 'en-US'
-**or for Canada**
+# or for Canada
 Faker::Config.locale = 'en-CA'
 
 # US only

--- a/doc/phone_number.md
+++ b/doc/phone_number.md
@@ -22,6 +22,8 @@ Faker::PhoneNumber.cell_phone #=> "(186)285-7925"
 # NOTE NOTE NOTE NOTE
 # For the 'US only' methods below, first you must do the following:
 Faker::Config.locale = 'en-US'
+**or for Canada**
+Faker::Config.locale = 'en-CA'
 
 # US only
 Faker::PhoneNumber.area_code #=> "201"

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -96,7 +96,7 @@ module Faker
       # with an array of values and selecting one of them.
       def fetch(key)
         fetched = sample(translate("faker.#{key}"))
-        if fetched && fetched.match(/^\//) and fetched.match(/\/$/) # A regex
+        if fetched && fetched.match(/^\//) && fetched.match(/\/$/) # A regex
           regexify(fetched)
         else
           fetched
@@ -108,7 +108,7 @@ module Faker
       def fetch_all(key)
         fetched = translate("faker.#{key}")
         fetched = fetched.last if fetched.size <= 1
-        if !fetched.respond_to?(:sample) && fetched.match(/^\//) and fetched.match(/\/$/) # A regex
+        if !fetched.respond_to?(:sample) && fetched.match(/^\//) && fetched.match(/\/$/) # A regex
           regexify(fetched)
         else
           fetched

--- a/lib/faker/phone_number.rb
+++ b/lib/faker/phone_number.rb
@@ -9,7 +9,7 @@ module Faker
         parse('cell_phone.formats')
       end
 
-      # US only
+      # US and Canada only
       def area_code
         begin
           fetch('phone_number.area_code')
@@ -18,7 +18,7 @@ module Faker
         end
       end
 
-      # US only
+      # US and Canada only
       def exchange_code
         begin
           fetch('phone_number.exchange_code')
@@ -27,7 +27,7 @@ module Faker
         end
       end
 
-      # US only
+      # US and Canada only
       # Can be used for both extensions and last four digits of phone number.
       # Since extensions can be of variable length, this method taks a length parameter
       def subscriber_number(length = 4)

--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -11,4 +11,26 @@ en-CA:
       domain_suffix: [ca, com, biz, info, name, net, org]
 
     phone_number:
-      formats: ['###-###-####', '(###)###-####', '###.###.####', '1-###-###-####', '###-###-#### x###', '(###)###-#### x###', '1-###-###-#### x###', '###.###.#### x###', '###-###-#### x####', '(###)###-#### x####', '1-###-###-#### x####', '###.###.#### x####', '###-###-#### x#####', '(###)###-#### x#####', '1-###-###-#### x#####', '###.###.#### x#####']
+      area_code: ["204", "226", "236", "249", "250", "289", "306", "343", "365", "403", "416", "418", "431", "437", "438", "450", "506", "514", "519", "579", "581", "587", "604", "613", "639", "647", "705", "709", "778", "780", "807", "819", "867", "873", "902", "905"]
+      exchange_code: ["201", "202", "203", "205", "206", "207", "208", "209", "210", "212", "213", "214", "215", "216", "217", "218", "219", "224", "225", "227", "228", "229", "231", "234", "239", "240", "248", "251", "252", "253", "254", "256", "260", "262", "267", "269", "270", "276", "281", "283", "301", "302", "303", "304", "305", "307", "308", "309", "310", "312", "313", "314", "315", "316", "317", "318", "319", "320", "321", "323", "330", "331", "334", "336", "337", "339", "347", "351", "352", "360", "361", "386", "401", "402", "404", "405", "406", "407", "408", "409", "410", "412", "413", "414", "415", "417", "419", "423", "424", "425", "434", "435", "440", "443", "445", "464", "469", "470", "475", "478", "479", "480", "484", "501", "502", "503", "504", "505", "507", "508", "509", "510", "512", "513", "515", "516", "517", "518", "520", "530", "540", "541", "551", "557", "559", "561", "562", "563", "564", "567", "570", "571", "573", "574", "580", "585", "586", "601", "602", "603", "605", "606", "607", "608", "609", "610", "612", "614", "615", "616", "617", "618", "619", "620", "623", "626", "630", "631", "636", "641", "646", "650", "651", "660", "661", "662", "667", "678", "682", "701", "702", "703", "704", "706", "707", "708", "712", "713", "714", "715", "716", "717", "718", "719", "720", "724", "727", "731", "732", "734", "737", "740", "754", "757", "760", "763", "765", "770", "772", "773", "774", "775", "781", "785", "786", "801", "802", "803", "804", "805", "806", "808", "810", "812", "813", "814", "815", "816", "817", "818", "828", "830", "831", "832", "835", "843", "845", "847", "848", "850", "856", "857", "858", "859", "860", "862", "863", "864", "865", "870", "872", "878", "901", "903", "904", "906", "907", "908", "909", "910", "912", "913", "914", "915", "916", "917", "918", "919", "920", "925", "928", "931", "936", "937", "940", "941", "947", "949", "952", "954", "956", "959", "970", "971", "972", "973", "975", "978", "979", "980", "984", "985", "989"]
+      formats:
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "1-#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "1-#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "1-#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "1-#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "(#{PhoneNumber.area_code}) #{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "1-#{PhoneNumber.area_code}-#{PhoneNumber.exchange_code}-#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"
+        - "#{PhoneNumber.area_code}.#{PhoneNumber.exchange_code}.#{PhoneNumber.subscriber_number} x#{PhoneNumber.extension}"

--- a/test/test_en_ca_locale.rb
+++ b/test/test_en_ca_locale.rb
@@ -10,6 +10,36 @@ class TestEnCaLocale < Test::Unit::TestCase
     Faker::Config.locale = @previous_locale
   end
 
+  def test_ca_phone_methods_return_nil_for_nil_locale
+    Faker::Config.locale = nil
+
+    assert_nil Faker::PhoneNumber.area_code
+    assert_nil Faker::PhoneNumber.exchange_code
+  end
+
+  def test_subscriber_number_method
+    assert Faker::PhoneNumber.subscriber_number.is_a? String
+    assert_equal Faker::PhoneNumber.subscriber_number.length, 4
+    assert_equal Faker::PhoneNumber.subscriber_number(10).length, 10
+    assert_equal Faker::PhoneNumber.method(:extension), Faker::PhoneNumber.method(:subscriber_number)
+  end
+
+  def test_ca_phone_methods_with_en_ca_locale
+    assert Faker::PhoneNumber.area_code.is_a? String
+    assert Faker::PhoneNumber.area_code.to_i.is_a? Integer
+    assert_equal Faker::PhoneNumber.area_code.length, 3
+
+    assert Faker::PhoneNumber.exchange_code.is_a? String
+    assert Faker::PhoneNumber.exchange_code.to_i.is_a? Integer
+    assert_equal Faker::PhoneNumber.exchange_code.length, 3
+  end
+
+  def test_validity_of_phone_method_output
+    # got the following regex from http://stackoverflow.com/a/123666/1210055 as an expression of the NANP standard.
+    ca_number_validation_regex = /^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/
+    assert_match(ca_number_validation_regex, Faker::PhoneNumber.phone_number)
+  end
+
   def test_ca_postcode
     expected = /[A-VX-Y][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
     assert_match(expected, Faker::Address.postcode)


### PR DESCRIPTION
US and Canada share the same telephone infrastructure so the concept of area codes and exchange codes (i.e. prefixes) are valid for `en-CA`. I think it might be beneficial also merge the `area_code` sections of `en-CA` and `en-US` as Canada and US both share `+1` as their country code. Essentially, they are the same country and locale as far as telephone communication is concerned.

Also should we also support toll free area codes?  Maybe add them to the `area_code` list or even have a special category for them so someone can create faker 800 numbers? See this page for more information: https://www.areacodelocations.info/8/800.html