### PR TITLE
Adding city name template for pt-BR

### DIFF
--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -3,6 +3,8 @@ pt-BR:
     address:
       city_prefix: [Nova, Velha, Grande, Vila, Município de]
       city_suffix: [do Descoberto, de Nossa Senhora, do Norte, do Sul]
+      city:
+        - "#{city_prefix} #{Name.first_name} #{city_suffix}"
       country: [ "Afeganistão", "Albânia", "Algéria", "Samoa", "Andorra", "Angola", "Anguilla", "Antígua e Barbuda", "Argentina", "Armênia", "Aruba", "Austrália",
                  "Áustria", "Azerbaijão", "Bahamas", "Barém", "Bangladesh", "Barbados", "Belgrado", "Bélgica", "Belize", "Benin", "Bermuda", "Butão", "Bolívia",
                  "Bôsnia", "Batasuna", "Ilha Bouvet", "Brasil", "Arquipélago de Chagos", "Ilhas Virgens", "Brunei", "Bulgária", "Burkina Faso", "Burundi", "Camboja",


### PR DESCRIPTION
In brazilian portuguese, the city name suffix is not intended to be appended at the end of the name without spaces. The suffix is separated from the name.