### PR TITLE
Fix bug when minumum password length is set to zero

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -61,7 +61,7 @@ module Faker
 
         if special_chars
           chars = %w(! @ # $ % ^ & *)
-          rand(min_length).times do |i|
+          (rand(min_length) + 1).times do |i|
             temp[i] = chars[rand(chars.length)]
           end
         end

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -1,7 +1,7 @@
 module Faker
   # Based on Perl's Text::Lorem
   class Lorem < Base
-    CHARACTERS = ('0'..'9').to_a + ('a'..'z').to_a
+    CHARACTERS = ('1'..'9').to_a + ('a'..'z').to_a
 
     class << self
       def word


### PR DESCRIPTION
I encountered some problems when used `Faker::Internet.password` methods  for test code.
There is a possibility that `min_length` is  set to zero when specify the `special_chars: true`.

ex)

Not contains special chars is generated

```rb
Faker::Internet.password(8, 16, true, true) #=> "2v6hOaGe0u"
```

REF

```rb
Faker::Internet.password(10, 20, true, true) #=> "*%NkOnJsH4"
```
https://github.com/stympy/faker/blob/master/doc/internet.md