### PR TITLE
Fixed fillmurray.image

### DIFF
--- a/lib/faker/fillmurray.rb
+++ b/lib/faker/fillmurray.rb
@@ -2,7 +2,7 @@ module Faker
   class Fillmurray < Base
     class << self
 
-      def image(grayscale = false, width = 200, height = 200)
+      def image(grayscale = false, width = '200', height = '200')
         raise ArgumentError, "Width should be a number" unless width.to_s.match(/^\d+$/)
         raise ArgumentError, "Height should be a number" unless height.to_s.match(/^\d+$/)
         raise ArgumentError, "Grayscale should be a boolean" unless [true, false].include?(grayscale)

--- a/test/test_faker_fillmurray.rb
+++ b/test/test_faker_fillmurray.rb
@@ -5,7 +5,11 @@ class TestFakerFillmurray < Test::Unit::TestCase
     @tester = Faker::Fillmurray
   end
 
-  def test_fillmurray
+  def test_fillmurray_with_no_arguments
+    assert @tester.image.match(/https:\/\/fillmurray\.com\/(\d+)\/(\d+)/)[1] != nil
+  end
+
+  def test_fillmurray_with_all_arguments
     assert @tester.image(false, '300', '300').match(/https:\/\/fillmurray\.com\/(\d+)\/(\d+)/) != nil
   end
 
@@ -17,7 +21,7 @@ class TestFakerFillmurray < Test::Unit::TestCase
     assert_raise ArgumentError do
       @tester.image(false, '300', 'nine-thousand')
     end
-      
+
   end
 
   def test_fillmurray_with_incorrect_width_format


### PR DESCRIPTION
Default values were integers, and thus calling `Faker::Fillmurray.image` didn't work.

Also added test for no arguments.