### PR TITLE
Add meaningful error message when country code not found

### DIFF
--- a/lib/faker/bank.rb
+++ b/lib/faker/bank.rb
@@ -13,6 +13,7 @@ module Faker
 
       def iban(bank_country_code="GB")
         details = iban_details.find { |country| country["bank_country_code"] == bank_country_code.upcase }
+        raise ArgumentError, "Could not find iban details for #{bank_country_code}" unless details
         bcc = details["bank_country_code"] + 2.times.map{ rand(10) }.join
         ilc = (0...details["iban_letter_code"].to_i).map{ (65 + rand(26)).chr }.join
         ib  = details["iban_digits"].to_i.times.map{ rand(10) }.join

--- a/test/test_faker_bank.rb
+++ b/test/test_faker_bank.rb
@@ -40,11 +40,10 @@ class TestFakerBank < Test::Unit::TestCase
   def test_iban_es; assert @tester.iban("es").match(/\d{20}/); end
   def test_iban_se; assert @tester.iban("se").match(/\d{20}/); end
   def test_iban_sk; assert @tester.iban("sk").match(/\d{24}/); end
+
+  def test_iban_invalid
+    assert_raise ArgumentError.new("Could not find iban details for bad") do
+       @tester.iban("bad")
+    end
+  end
 end
-
-
-
-
-
-
-


### PR DESCRIPTION
Thought it would be a good idea to raise a meaningful message when trying to create an `iban` when the `bank_country_code` is not found.

It should mean we don't get error messages like the one described in #910 