### PR TITLE
edit superclass

### DIFF
--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -1,5 +1,5 @@
 module Faker
-  class Time < Date
+  class Time < Faker::Date
     TIME_RANGES = {
       :all => (0..23),
       :day => (9..17),


### PR DESCRIPTION
no error in OS X , ruby 2.2.4 , faker-1.8.0
error in ubuntu 14.04 , ruby 2.2.4 , faker-1.8.0

cause wrong superclass use.

in OS X , no error
<img width="682" alt="screen shot 2017-07-10 at 4 20 58 pm" src="https://user-images.githubusercontent.com/979297/28007686-53874fd4-658f-11e7-8901-96a179609e0b.png">

in ubuntu , error
<img width="654" alt="screen shot 2017-07-10 at 4 21 00 pm" src="https://user-images.githubusercontent.com/979297/28007698-64ba83de-658f-11e7-9419-f6e7937083e2.png">
