### PR TITLE
Fix Address.community documentation

### DIFF
--- a/doc/address.md
+++ b/doc/address.md
@@ -11,7 +11,7 @@ Faker::Address.secondary_address #=> "Apt. 672"
 
 Faker::Address.building_number #=> "7304"
 
-Faker::Address.community #=> "University Crossing Apartments"
+Faker::Address.community #=> "University Crossing"
 
 Faker::Address.zip_code #=> "58517" or "23285-4905"
 


### PR DESCRIPTION
I unintentionally left in the word "Apartments" in the documentation for `Address.community`. 😨 This commit undoes that to make the documentation reflect actual behavior.

If, by chance, a secondary suffix (like "Apartments", "Condominiums") or other permutation (`The #{prefix} at #{prefix} #{suffix}`) is desired behavior, please let me know and I can implement them. In the meantime, here's a fix to keep the documentation honest. Sorry for the oversight.