### PR TITLE
[docs] Specify version number each class was introduced

### DIFF
--- a/doc/address.md
+++ b/doc/address.md
@@ -1,5 +1,7 @@
 # Faker::Address
 
+Available since version 0.3.0.
+
 ```ruby
 Faker::Address.city #=> "Imogeneborough"
 

--- a/doc/ancient.md
+++ b/doc/ancient.md
@@ -1,5 +1,7 @@
 # Faker::Ancient
 
+Available since version 1.7.0.
+
 ```ruby
 Faker::Ancient.god #=> "Zeus"
 

--- a/doc/app.md
+++ b/doc/app.md
@@ -1,5 +1,7 @@
 # Faker::App
 
+Available since version 1.4.3.
+
 ```ruby
 Faker::App.name #=> "Treeflex"
 

--- a/doc/beer.md
+++ b/doc/beer.md
@@ -1,5 +1,7 @@
 # Faker::Beer
 
+Available since version 1.6.2.
+
 ```ruby
 Faker::Beer.name #=> "Hercules Double IPA"
 

--- a/doc/boolean.md
+++ b/doc/boolean.md
@@ -1,5 +1,7 @@
 # Faker::Boolean
 
+Available since version 1.6.2.
+
 ```ruby
 # Optional parameter: true_ratio=0.5
 Faker::Boolean.boolean #=> true

--- a/doc/cat.md
+++ b/doc/cat.md
@@ -1,5 +1,7 @@
 # Faker::Cat
 
+Available since version 1.6.2.
+
 ```ruby
 # Random cat name
 Faker::Cat.name #=> "Shadow"

--- a/doc/chuck_norris.md
+++ b/doc/chuck_norris.md
@@ -1,5 +1,7 @@
 # Faker::ChuckNorris
 
+Available since version 1.6.4.
+
 ```ruby
 Faker::ChuckNorris.fact #=> "Chuck Norris can solve the Towers of Hanoi in one move."
 ```

--- a/doc/compass.md
+++ b/doc/compass.md
@@ -1,5 +1,7 @@
 # Faker::Compass
 
+Available since version 1.8.0.
+
 ```ruby
 # A random direction
 Faker::Compass.direction                 #=> "southeast"

--- a/doc/crypto.md
+++ b/doc/crypto.md
@@ -1,5 +1,7 @@
 # Faker::Crypto
 
+Available since version 1.6.4.
+
 ```ruby
 Faker::Crypto.md5 #=> "6b5ed240042e8a65c55ddb826c3408e6"
 

--- a/doc/demographic.md
+++ b/doc/demographic.md
@@ -1,5 +1,7 @@
 # Faker::Demographic
 
+Available since version 1.7.3.
+
 ```ruby
 Faker::Demographic.race #=> "Native Hawaiian or Other Pacific Islander"
 

--- a/doc/dessert.md
+++ b/doc/dessert.md
@@ -1,5 +1,7 @@
 # Faker::Dessert
 
+Available since version 1.8.0.
+
 ```ruby
 # Random dessert variety
 Faker::Dessert.variety #=> "Cake"

--- a/doc/dragon_ball.md
+++ b/doc/dragon_ball.md
@@ -1,5 +1,7 @@
 # Faker::DragonBall
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::DragonBall.character #=> "Goku"
 ```

--- a/doc/educator.md
+++ b/doc/educator.md
@@ -1,5 +1,7 @@
 # Faker::Educator
 
+Available since version 1.6.4.
+
 ```ruby
 Faker::Educator.university #=> "Mallowtown Technical College"
 

--- a/doc/file.md
+++ b/doc/file.md
@@ -1,5 +1,7 @@
 # Faker::File
 
+Available since version 1.6.4.
+
 ```ruby
 Faker::File.extension #=> "mp3"
 

--- a/doc/fillmurray.md
+++ b/doc/fillmurray.md
@@ -1,5 +1,7 @@
 # Faker::Fillmurray
 
+Available since version 1.7.1.
+
 ```ruby
 Faker::Fillmurray.image #=> "http://fillmurray.com/300/300"
 

--- a/doc/food.md
+++ b/doc/food.md
@@ -1,5 +1,7 @@
 # Faker::Food
 
+Available since version 1.7.0.
+
 ```ruby
 Faker::Food.dish #=> "Caesar Salad"
 

--- a/doc/friends.md
+++ b/doc/friends.md
@@ -1,5 +1,7 @@
 # Faker::Friends
 
+Available since version 1.7.3.
+
 ```ruby
 Faker::Friends.character #=> "Rachel Green"
 

--- a/doc/funny_name.md
+++ b/doc/funny_name.md
@@ -1,5 +1,7 @@
 # Faker::FunnyName
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::FunnyName.name #=> "Sam Pull"
 

--- a/doc/game_of_thrones.md
+++ b/doc/game_of_thrones.md
@@ -1,5 +1,7 @@
 # Faker::GameOfThrones
 
+Available since version 1.6.6.
+
 ```ruby
 Faker::GameOfThrones.character #=> "Tyrion Lannister"
 

--- a/doc/harry_potter.md
+++ b/doc/harry_potter.md
@@ -1,5 +1,7 @@
 # Faker::HarryPotter
 
+Available since version 1.7.3.
+
 ```ruby
 Faker::HarryPotter.character #=> "Harry Potter"
 

--- a/doc/hey_arnold.md
+++ b/doc/hey_arnold.md
@@ -1,5 +1,7 @@
 # Faker::HeyArnold
 
+Available since version 1.8.0.
+
 ```ruby
 
 Faker::HeyArnold.character #=> "Arnold"

--- a/doc/hitchhikers_guide_to_the_galaxy.md
+++ b/doc/hitchhikers_guide_to_the_galaxy.md
@@ -1,5 +1,7 @@
 # Faker::HitchhikersGuideToTheGalaxy
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::HitchhikersGuideToTheGalaxy.character #=> "Marvin"
 

--- a/doc/hobbit.md
+++ b/doc/hobbit.md
@@ -1,10 +1,12 @@
 # Faker::Hobbit
 
+Available since version 1.8.0.
+
 ```ruby
 # Any character from the book
 Faker::Hobbit.character #=> "Gandalf the Grey"
 
-# One of the 13 dwarves from the Company, or Gandalf, or Bilbo 
+# One of the 13 dwarves from the Company, or Gandalf, or Bilbo
 Faker::Hobbit.thorins_company #=> "Thorin Oakenshield"
 
 Faker::Hobbit.quote #=> "Never laugh at live dragons, Bilbo you fool!"

--- a/doc/how_i_met_your_mother.md
+++ b/doc/how_i_met_your_mother.md
@@ -1,5 +1,7 @@
 # Faker::HowIMetYourMother
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::HowIMetYourMother.character #=> "Barney Stinson"
 

--- a/doc/league_of_legends.md
+++ b/doc/league_of_legends.md
@@ -1,5 +1,7 @@
 # Faker::LeagueOfLegends
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::LeagueOfLegends.champion #=> "Jarvan IV"
 

--- a/doc/lorem_pixel.md
+++ b/doc/lorem_pixel.md
@@ -1,5 +1,7 @@
 # Faker::LoremPixel
 
+Available since version 1.7.0.
+
 ```ruby
 Faker::LoremPixel.image #=> "http://lorempixel.com/300/300"
 

--- a/doc/markdown.md
+++ b/doc/markdown.md
@@ -1,5 +1,7 @@
 # Faker::Markdown
 
+Available since version 1.8.0.
+
 Generates markdown formatting with Lorem Ipsum text
 
 ```ruby

--- a/doc/matz.md
+++ b/doc/matz.md
@@ -1,5 +1,7 @@
 # Faker::Matz
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::Matz.quote #=> "You want to enjoy life, don't you? If you get your job done quickly and your job is fun, that's good isn't it? That's the purpose of life, partly. Your life is better."
 ```

--- a/doc/music.md
+++ b/doc/music.md
@@ -1,5 +1,7 @@
 # Faker::Music
 
+Available since version 1.6.4.
+
 ```ruby
 Faker::Music.key #=> "C"
 

--- a/doc/omniauth.md
+++ b/doc/omniauth.md
@@ -1,5 +1,7 @@
 # Faker::Omniauth
 
+Available since version 1.8.0.
+
 [Omniauth](https://github.com/omniauth/omniauth) is a library that standardizes multi-provider authentication for web applications.  Each of the following methods will return a randomized hash that mimics the hash returned by each of these omniauth strategies.
 
 ```

--- a/doc/overwatch.md
+++ b/doc/overwatch.md
@@ -1,5 +1,7 @@
 # Faker::Overwatch
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::Overwatch.hero #=> "Tracer"
 

--- a/doc/pokemon.md
+++ b/doc/pokemon.md
@@ -1,5 +1,7 @@
 # Faker::Pokemon
 
+Available since version 1.7.0.
+
 ```ruby
 Faker::Pokemon.name #=> "Pikachu"
 

--- a/doc/rick_and_morty.md
+++ b/doc/rick_and_morty.md
@@ -1,5 +1,7 @@
 # Faker::RickAndMorty
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::RickAndMorty.character #=> "Rick Sanchez"
 

--- a/doc/robin.md
+++ b/doc/robin.md
@@ -1,5 +1,7 @@
 # Faker::Robin
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::Robin.quote #=> "Holy Razors Edge"
 Faker::Robin.quote #=> "Holy Alter Ego"

--- a/doc/rupaul.md
+++ b/doc/rupaul.md
@@ -1,5 +1,7 @@
 # Faker::RuPaul
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::RuPaul.quote #=> "That's Funny, Tell Another One"
 ```

--- a/doc/simpsons.md
+++ b/doc/simpsons.md
@@ -1,5 +1,7 @@
 # Faker::Simpsons
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::Simpsons.character #=> "Charles Montgomery Burns"
 

--- a/doc/slack_emoji.md
+++ b/doc/slack_emoji.md
@@ -1,5 +1,7 @@
 # Faker::SlackEmoji
 
+Available since version 1.5.0.
+
 ```ruby
 # Random Slack Emoji from people category
 Faker::SlackEmoji.people #=> ":sleepy:"

--- a/doc/space.md
+++ b/doc/space.md
@@ -1,5 +1,7 @@
 # Faker::Space
 
+Available since version 1.6.4.
+
 ```ruby
 # Random planet from our Solar System
 Faker::Space.planet #=> "Venus"

--- a/doc/star_trek.md
+++ b/doc/star_trek.md
@@ -1,5 +1,7 @@
 # Faker::StarTrek
 
+Available since version 1.8.0.
+
 ```ruby
 Faker::StarTrek.character #=> "Spock"
 

--- a/doc/star_wars.md
+++ b/doc/star_wars.md
@@ -1,5 +1,7 @@
 # Faker::StarWars
 
+Available since version 1.6.2.
+
 ```ruby
 Faker::StarWars.character #=> "Anakin Skywalker"
 

--- a/doc/superhero.md
+++ b/doc/superhero.md
@@ -1,5 +1,7 @@
 # Faker::Superhero
 
+Available since version 1.6.2.
+
 ```ruby
 # Random Superhero name
 Faker::Superhero.name #=> "Magnificent Shatterstar"

--- a/doc/twin_peaks.md
+++ b/doc/twin_peaks.md
@@ -1,5 +1,7 @@
 # Faker::TwinPeaks
 
+Available since version 1.7.0.
+
 ```ruby
 Faker::TwinPeaks.character #=> "Dale Cooper"
 

--- a/doc/twitter.md
+++ b/doc/twitter.md
@@ -1,5 +1,7 @@
 # Faker::Twitter
 
+Available since version 1.7.3.
+
 Generate realistic Twitter user and status objects similar to what you would get back from the API.
 
 ```json

--- a/doc/university.md
+++ b/doc/university.md
@@ -1,5 +1,7 @@
 # Faker::University
 
+Available since version 1.5.0.
+
 ```ruby
 # Random University Name
 Faker::University.name #=> "South Texas College"

--- a/doc/vehicle.md
+++ b/doc/vehicle.md
@@ -1,5 +1,7 @@
 # Faker::Vehicle
 
+Available since version 1.6.4.
+
 ```ruby
 # Generate vehicle identification number
 Faker::Vehicle.vin #=> "LLDWXZLG77VK2LUUF"

--- a/doc/zelda.md
+++ b/doc/zelda.md
@@ -1,5 +1,7 @@
 # Faker::Zelda
 
+Available since version 1.7.3.
+
 ```ruby
 # Random Zelda game
 Faker::Zelda.game #=> "Ocarina of Time"


### PR DESCRIPTION
I updated all of the Fakers that I could find in the CHANGELOG. The original issue by @ricardograca didn't propose a clean way to document when specific methods were introduced, so this is based on the initial implementation of the Faker

I didn't include it on the large base README as I felt it would clutter that view too much. 