### PR TITLE
[#976] Handles zero as max for rand

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -205,7 +205,13 @@ module Faker
       end
 
       def rand(max = nil)
-        max ? Faker::Config.random.rand(max) : Faker::Config.random.rand
+        if max.nil?
+          Faker::Config.random.rand
+        elsif max.is_a?(Range) || max.to_i > 0
+          Faker::Config.random.rand(max)
+        else
+          0
+        end
       end
     end
   end

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -45,7 +45,7 @@ module Faker
       end
 
       def question(word_count = 4, supplemental = false, random_words_to_add = 6)
-        words(word_count + rand(random_words_to_add.to_i).to_i, supplemental).join(' ').capitalize + '?'
+        words(word_count + rand(random_words_to_add.to_i), supplemental).join(' ').capitalize + '?'
       end
 
       def questions(question_count = 3, supplemental = false)

--- a/test/test_faker.rb
+++ b/test/test_faker.rb
@@ -66,7 +66,30 @@ class TestFaker < Test::Unit::TestCase
     Faker::Config.random = Random.new(42)
     assert v == Faker::Base.rand_in_range(0, 1000)
   end
-  
+
+  def test_rand_for_nil
+    assert_nothing_raised ArgumentError do
+      Faker::Base.rand(nil)
+    end
+    assert_nothing_raised ArgumentError do
+      Faker::Base.rand
+    end
+  end
+
+  def test_rand_for_zero
+    assert_nothing_raised ArgumentError do
+      Faker::Base.rand(0)
+    end
+    assert_equal 0, Faker::Base.rand(0)
+  end
+
+  def test_rand_for_range
+    assert_nothing_raised ArgumentError do
+      Faker::Base.rand(0..6)
+    end
+    assert_includes 0..6, Faker::Base.rand(0..6)
+  end
+
   def test_unique
     unique_numbers = 8.times.map do
       Faker::Base.unique.numerify('#')
@@ -74,5 +97,4 @@ class TestFaker < Test::Unit::TestCase
 
     assert_equal(unique_numbers.uniq, unique_numbers)
   end
-
 end

--- a/test/test_faker_lorem.rb
+++ b/test/test_faker_lorem.rb
@@ -50,6 +50,10 @@ class TestFakerLorem < Test::Unit::TestCase
     100.times { assert @standard_wordlist.include?(@tester.word) }
   end
 
+  def test_exact_sentence_word_count
+    assert_equal 2, @tester.sentence(2, false, 0).split(' ').length
+  end
+
   def test_exact_count_param
     assert(@tester.characters(2).length == 2)
     assert(@tester.words(2).length == 2)


### PR DESCRIPTION
Improve `Faker::Base.rand` to handle zero (0) as max value and restore
documented behaviour for some methods that depend on it

Closes #976 

Notes:
Could not restore `Kernel.rand` behavior since now there're a couple of Fakers depending on `Random::DEFAULT` behavior (Bitcoin being one). I had to handle this internally on the `Faker::Base.rand`. 
Any suggestion is welcome