### PR TITLE
Freeze all constant objects

### DIFF
--- a/lib/faker/avatar.rb
+++ b/lib/faker/avatar.rb
@@ -1,8 +1,7 @@
 module Faker
   class Avatar < Base
+    SUPPORTED_FORMATS = %w(png jpg bmp).freeze
     class << self
-      SUPPORTED_FORMATS = %w(png jpg bmp)
-
       def image(slug = nil, size = '300x300', format = 'png', set = 'set1', bgset = nil)
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)

--- a/lib/faker/bitcoin.rb
+++ b/lib/faker/bitcoin.rb
@@ -3,13 +3,14 @@ require 'securerandom'
 
 module Faker
   class Bitcoin < Base
+    PROTOCOL_VERSIONS = {
+      main: 0,
+      testnet: 111
+    }.freeze
+
+    ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'.freeze
+
     class << self
-
-      PROTOCOL_VERSIONS = {
-        main: 0,
-        testnet: 111
-      }
-
       def address
         address_for(:main)
       end
@@ -21,20 +22,17 @@ module Faker
       protected
 
       def base58(str)
-        alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-        base = alphabet.size
-
         lv = 0
-        str.split('').reverse.each_with_index { |v,i| lv += v.unpack('C')[0] * 256**i }
+        str.split('').reverse.each_with_index { |v, i| lv += v.unpack('C')[0] * 256**i }
 
         ret = ''
         while lv > 0 do
-          lv, mod = lv.divmod(base)
-          ret << alphabet[mod]
+          lv, mod = lv.divmod(ALPHABET.size)
+          ret << ALPHABET[mod]
         end
 
         npad = str.match(/^#{0.chr}*/)[0].to_s.size
-        '1'*npad + ret.reverse
+        '1' * npad + ret.reverse
       end
 
       def address_for(network)

--- a/lib/faker/code.rb
+++ b/lib/faker/code.rb
@@ -128,8 +128,8 @@ module Faker
         values << (check_digit == 10 ? 0 : check_digit).to_s
       end
 
-      EAN_CHECK_DIGIT8 = [3, 1, 3, 1, 3, 1, 3]
-      EAN_CHECK_DIGIT13 = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
+      EAN_CHECK_DIGIT8 = [3, 1, 3, 1, 3, 1, 3].freeze
+      EAN_CHECK_DIGIT13 = [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3].freeze
 
       def rut_verificator_digit(rut)
         total = rut.to_s.rjust(8, '0').split(//).zip(%w(3 2 7 6 5 4 3 2)).collect{|a, b| a.to_i * b.to_i}.inject(:+)

--- a/lib/faker/id_number.rb
+++ b/lib/faker/id_number.rb
@@ -2,12 +2,12 @@ module Faker
   class IDNumber < Base
 
     INVALID_SSN = [
-        /0{3}-\d{2}-\d{4}/,
-        /\d{3}-0{2}-\d{4}/,
-        /\d{3}-\d{2}-0{4}/,
-        /666-\d{2}-\d{4}/,
-        /9\d{2}-\d{2}-\d{4}/
-    ]
+      /0{3}-\d{2}-\d{4}/,
+      /\d{3}-0{2}-\d{4}/,
+      /\d{3}-\d{2}-0{4}/,
+      /666-\d{2}-\d{4}/,
+      /9\d{2}-\d{2}-\d{4}/
+    ].freeze
 
     class << self
 
@@ -31,6 +31,5 @@ module Faker
         parse("id_number.#{key}")
       end
     end
-
   end
 end

--- a/lib/faker/lorem_pixel.rb
+++ b/lib/faker/lorem_pixel.rb
@@ -1,8 +1,8 @@
 module Faker
   class LoremPixel < Base
+    SUPPORTED_CATEGORIES = %w(abstract animals business cats city food nightlife
+                              fashion people nature sports technics transport).freeze
     class << self
-      SUPPORTED_CATEGORIES = %w(abstract animals business cats city food nightlife fashion people nature sports technics transport)
-
       def image(size = '300x300', is_gray = false, category = nil, number = nil, text = nil)
         raise ArgumentError, 'Size should be specified in format 300x300' unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)

--- a/lib/faker/placeholdit.rb
+++ b/lib/faker/placeholdit.rb
@@ -1,8 +1,8 @@
 module Faker
   class Placeholdit < Base
-    class << self
-      SUPPORTED_FORMATS = %w(png jpg gif jpeg)
+    SUPPORTED_FORMATS = %w(png jpg gif jpeg).freeze
 
+    class << self
       def image(size = '300x300', format = 'png', background_color = nil, text_color = nil, text = nil)
         raise ArgumentError, "Size should be specified in format 300x300" unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)

--- a/lib/faker/time.rb
+++ b/lib/faker/time.rb
@@ -8,7 +8,7 @@ module Faker
       :afternoon => (12..17),
       :evening => (17..21),
       :midnight => (0..4)
-    }
+    }.freeze
 
     class << self
       def between(from, to, period = :all, format = nil)

--- a/lib/faker/vehicle.rb
+++ b/lib/faker/vehicle.rb
@@ -1,8 +1,8 @@
 module Faker
   class Vehicle < Base
-    VIN_CHARS = '0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ'
-    VIN_MAP = '0123456789X'
-    VIN_WEIGHTS = '8765432X098765432'
+    VIN_CHARS = '0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ'.freeze
+    VIN_MAP = '0123456789X'.freeze
+    VIN_WEIGHTS = '8765432X098765432'.freeze
 
     class << self
       #ISO 3779

--- a/lib/faker/version.rb
+++ b/lib/faker/version.rb
@@ -1,3 +1,3 @@
 module Faker #:nodoc:
-  VERSION = "1.8.2"
+  VERSION = "1.8.2".freeze
 end


### PR DESCRIPTION
Freeze constants to improve memory usage

Using:
```ruby
require 'faker'
require 'benchmark/memory'

Benchmark.memory do |x|
  x.report('frozen') do
    100.times do
      Faker::Bitcoin.address
    end
  end
end
```

Before change:
```
Calculating -------------------------------------
                 old   108.071M memsize (   106.270M retained)
                       829.435k objects (   792.229k retained)
                        50.000  strings (    50.000  retained)
```

After change:
```
Calculating -------------------------------------
                 new     1.825M memsize (     3.667k retained)
                        37.382k objects (    16.000  retained)
                        50.000  strings (    11.000  retained)
```