### PR TITLE
Fix for NL postal code

### DIFF
--- a/lib/locales/nl.yml
+++ b/lib/locales/nl.yml
@@ -44,7 +44,7 @@ nl:
 
       street_address:
         - "#{street_name} #{building_number}"
-      postcode: ["#### ??"]
+      postcode: /\d{4} [A-Z]{2}(?<!SA|SS|SD)/
       state: ["Noord-Holland", "Zuid-Holland", "Utrecht", "Zeeland", "Overijssel", "Gelderland", "Drenthe", "Friesland", "Groningen", "Noord-Brabant", "Limburg"]
       default_country: [Nederland]
 

--- a/test/test_nl_locale.rb
+++ b/test/test_nl_locale.rb
@@ -1,0 +1,50 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
+class TestNlLocale < Test::Unit::TestCase
+  def setup
+    @previous_locale = Faker::Config.locale
+    Faker::Config.locale = 'nl'
+  end
+
+  def teardown
+    Faker::Config.locale = nil
+  end
+
+  def test_nl_methods
+    assert Faker::Address.building_number.is_a? String
+    assert Faker::Address.secondary_address.is_a? String
+    assert Faker::Address.postcode.is_a? String
+    assert Faker::Address.state.is_a? String
+    assert Faker::Address.city.is_a? String
+    assert Faker::Address.city_prefix.is_a? String
+    assert Faker::Address.city_suffix.is_a? String
+    assert Faker::Address.street_suffix.is_a? String
+    assert Faker::Address.street_name.is_a? String
+    assert Faker::Address.street_address.is_a? String
+    assert Faker::Address.default_country.is_a? String
+    assert Faker::Company.suffix.is_a? String
+    assert Faker::Company.buzzword.is_a? String
+    assert Faker::Company.bs.is_a? String
+    assert Faker::Company.name.is_a? String
+    assert Faker::Internet.free_email.is_a? String
+    assert Faker::Internet.domain_suffix.is_a? String
+    assert Faker::Lorem.word.is_a? String
+    assert Faker::Name.first_name.is_a? String
+    assert Faker::Name.last_name.is_a? String
+    assert Faker::Name.title.is_a? String
+    assert Faker::Name.name.is_a? String
+    assert Faker::PhoneNumber.phone_number.is_a? String
+    assert Faker::PhoneNumber.cell_phone.is_a? String
+    assert Faker::Book.title.is_a? String
+    assert Faker::Book.author.is_a? String
+    assert Faker::Book.publisher.is_a? String
+  end
+
+  def test_nl_postcode
+    assert_match(/\d{4} [A-Z]{2}(?<!SA|SS|SD)/, Faker::Address.postcode)
+  end
+
+  def test_nl_is_default_country
+    assert_equal('Nederland', Faker::Address.default_country)
+  end
+end


### PR DESCRIPTION
According to wikipedia, https://en.wikipedia.org/wiki/Postal_codes_in_the_Netherlands
the postal code for the Netherlands should not include one of SA, SD, SS
as a suffix. This is now fixed.

Also added test for nl_locale