### PR TITLE
Add french company SIREN and SIRET numbers

### DIFF
--- a/doc/company.md
+++ b/doc/company.md
@@ -22,6 +22,10 @@ Faker::Company.logo #=> "https://pigment.github.com/fake-logos/logos/medium/colo
 
 Faker::Company.swedish_organisation_number #=> "7962578022"
 
+Faker::Company.french_siren_number #=> "819489626"
+
+Faker::Company.french_siret_number #=> "81948962600013"
+
 Faker::Company.norwegian_organisation_number #=> "839071558"
 
 # Generate an Australian Business Number

--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -52,6 +52,18 @@ module Faker
         base + luhn_algorithm(base).to_s
       end
 
+      # Get a random French SIREN number. See more here https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_entreprises
+      def french_siren_number
+        base = (1..8).map { rand(10) }.join
+        base + luhn_algorithm(base).to_s
+      end
+
+      def french_siret_number
+        location = rand(100).to_s.rjust(4, '0')
+        org_no = french_siren_number + location
+        org_no + luhn_algorithm(org_no).to_s
+      end
+
       # Get a random Norwegian organization number. Info: https://www.brreg.no/om-oss/samfunnsoppdraget-vart/registera-vare/einingsregisteret/organisasjonsnummeret/
       def norwegian_organisation_number
         # Valid leading digit: 8, 9

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -29,6 +29,19 @@ class TestFakerCompany < Test::Unit::TestCase
     assert org_no[9] == @tester.send(:luhn_algorithm, org_no[0..8]).to_s
   end
 
+  def test_french_siren_number
+    siren = @tester.french_siren_number
+    assert siren.match(/\A\d{9}\z/)
+    assert siren[8] == @tester.send(:luhn_algorithm, siren[0..-2]).to_s
+  end
+
+  def test_french_siret_number
+    siret = @tester.french_siret_number
+    assert siret.match(/\A\d{14}\z/)
+    assert siret[8] == @tester.send(:luhn_algorithm, siret[0..7]).to_s
+    assert siret[13] == @tester.send(:luhn_algorithm, siret[0..-2]).to_s
+  end
+
   def test_norwegian_organisation_number
     org_no = @tester.norwegian_organisation_number
     assert org_no.match(/\d{9}/)


### PR DESCRIPTION
This adds French organization numbers to Faker::Company.

Related information [in French](https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_entreprises) (automatically translated [here](https://translate.google.com/translate?sl=fr&tl=en&js=y&prev=_t&hl=en&ie=UTF-8&u=https%3A%2F%2Ffr.wikipedia.org%2Fwiki%2FSyst%25C3%25A8me_d%2527identification_du_r%25C3%25A9pertoire_des_entreprises&edit-text=)) and (much less exhaustive) [in English](https://en.wikipedia.org/wiki/SIREN_code).