### PR TITLE
Add a row of hyphens to Markdown tables

### DIFF
--- a/doc/markdown.md
+++ b/doc/markdown.md
@@ -21,8 +21,8 @@ Faker::Markdown.inline_code #=> "Aut eos quis suscipit. `Dignissimos voluptatem 
 # Code Block - generates a code block formatted in ruby
 Faker::Markdown.block_code #=> "```ruby\nEos quasi qui.\n```"
 
-# Table - generates a 3x3 table
-Faker::Markdown.table #=> "ad | similique | voluptatem\ncorrupti | est | rerum\nmolestiae | quidem | et"
+# Table - generates a 3x4 table with a row of headings, a row of hyphens and two rows of data
+Faker::Markdown.table #=> "ad | similique | voluptatem\n---- | ---- | ----\ncorrupti | est | rerum\nmolestiae | quidem | et"
 
 # Random - randomly chooses an above method
 Faker::Markdown.random #=> returns output from a single method outlined above

--- a/lib/faker/markdown.rb
+++ b/lib/faker/markdown.rb
@@ -48,6 +48,7 @@ module Faker
         3.times do
           table << "#{Lorem.word} | #{Lorem.word} | #{Lorem.word}"
         end
+        table.insert(1, '---- | ---- | ----')
         table.join("\n")
       end
 

--- a/test/test_faker_markdown.rb
+++ b/test/test_faker_markdown.rb
@@ -58,8 +58,8 @@ class TestFakerMarkdown < Test::Unit::TestCase
     test_trigger.each do |table_data|
       assert_instance_of(String, table_data)
     end
-
-    assert_equal(test_trigger.length, 3)
+    assert_equal(test_trigger.length, 4)
+    assert_equal(test_trigger[1], "---- | ---- | ----")
   end
 
   def test_random


### PR DESCRIPTION
More often than not, flavours of Markdown require tables have a row of hyphens that signify the first row contains headings. Here are the appropriate sections of documentation supporting this from [Github](https://help.github.com/articles/organizing-information-with-tables/), [Reddit](https://www.reddit.com/wiki/commenting#wiki_tables), [Gitlab](https://docs.gitlab.com/ce/user/markdown.html#tables) and [Stack Overflow](https://stackoverflow.com/editing-help#tables).