### PR TITLE
Prevent key object type mismatch on Faker::Bank.iban

### DIFF
--- a/lib/faker/bank.rb
+++ b/lib/faker/bank.rb
@@ -13,7 +13,8 @@ module Faker
 
       def iban(country_code = "GB")
         [
-          country_code.upcase + Array.new(2) { rand(10) }.join,
+          country_code.upcase,
+          Array.new(2) { rand(10) },
           iban_range(country_code, :letter_code) { (65 + rand(26)).chr },
           iban_range(country_code, :digits) { rand(10) }
         ].join

--- a/lib/faker/bank.rb
+++ b/lib/faker/bank.rb
@@ -11,21 +11,26 @@ module Faker
         fetch('bank.swift_bic')
       end
 
-      def iban(bank_country_code="GB")
-        details = iban_details.find { |country| country["bank_country_code"] == bank_country_code.upcase }
-        raise ArgumentError, "Could not find iban details for #{bank_country_code}" unless details
-        bcc = details["bank_country_code"] + 2.times.map{ rand(10) }.join
-        ilc = (0...details["iban_letter_code"].to_i).map{ (65 + rand(26)).chr }.join
-        ib  = details["iban_digits"].to_i.times.map{ rand(10) }.join
-        bcc + ilc + ib
+      def iban(country_code = "GB")
+        [
+          country_code.upcase + Array.new(2) { rand(10) }.join,
+          iban_range(country_code, :letter_code) { (65 + rand(26)).chr },
+          iban_range(country_code, :digits) { rand(10) }
+        ].join
       end
 
       private
 
-      def iban_details
-        fetch_all('bank.iban_details')
+      def iban_range(country_code, number_type)
+        array_length = iban_length(country_code, number_type)
+        Array.new(array_length) { yield }
+      end
+
+      def iban_length(country_code, number_type)
+        fetch("bank.iban_details.#{country_code.downcase}.#{number_type}").to_i
+      rescue I18n::MissingTranslationData
+        raise ArgumentError, "Could not find iban details for #{country_code}"
       end
     end
   end
 end
-

--- a/lib/locales/en/bank.yml
+++ b/lib/locales/en/bank.yml
@@ -75,7 +75,7 @@ en:
           digits: '26'
         nl:
           letter_code: '4'
-          digits: '12'
+          digits: '10'
         ro:
           letter_code: '4'
           digits: '18'

--- a/lib/locales/en/bank.yml
+++ b/lib/locales/en/bank.yml
@@ -4,84 +4,84 @@ en:
       name: ["UBS CLEARING AND EXECUTION SERVICES LIMITED", "ABN AMRO CORPORATE FINANCE LIMITED", "ABN AMRO FUND MANAGERS LIMITED", "ABN AMRO HOARE GOVETT SECURITIES", "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD.", "ALKEN ASSET MANAGEMENT", "ALKEN ASSET MANAGEMENT", "ABN AMRO HOARE GOVETT LIMITED", "AAC CAPITAL PARTNERS LIMITED", "ABBOTSTONE AGRICULTURAL PROPERTY UNIT TRUST", "ABN AMRO QUOTED INVESTMENTS (UK) LIMITED", "ABN AMRO MEZZANINE (UK) LIMITED", "ABBEY LIFE", "SANTANDER UK PLC", "OTKRITIE SECURITIES LIMITED", "ABC INTERNATIONAL BANK PLC", "ALLIED BANK PHILIPPINES (UK) PLC", "ABU DHABI ISLAMIC BANK", "ABG SUNDAL COLLIER LIMITED", "PGMS (GLASGOW) LIMITED", "ABINGWORTH MANAGEMENT LIMITED", "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV)"]
       swift_bic: ["AACCGB21", "AACNGB21", "AAFMGB21", "AAHOGB21", "AAHVGB21", "AANLGB21", "AANLGB2L", "AAOGGB21", "AAPEGB21", "AAPUGB21", "AAQIGB21", "ABAZGB21", "ABBEGB21", "ABBYGB2L", "ABCCGB22", "ABCEGB2L", "ABCMGB21", "ABDIGB21", "ABECGB21", "ABFIGB21", "ABMNGB21", "ABNAGB21VOC" ]
       iban_details:
-        - bank_country_code: "AT"
-          iban_letter_code: '0'
-          iban_digits: '18'
-        - bank_country_code: "BG"
-          iban_letter_code: '4'
-          iban_digits: '14'
-        - bank_country_code: "BE"
-          iban_letter_code: '0'
-          iban_digits: '14'
-        - bank_country_code: "CY"
-          iban_letter_code: '0'
-          iban_digits: '26'
-        - bank_country_code: "CZ"
-          iban_letter_code: '0'
-          iban_digits: '22'
-        - bank_country_code: "DE"
-          iban_letter_code: '0'
-          iban_digits: '20'
-        - bank_country_code: "DK"
-          iban_letter_code: '0'
-          iban_digits: '16'
-        - bank_country_code: "EE"
-          iban_letter_code: '0'
-          iban_digits: '18'
-        - bank_country_code: "ES"
-          iban_letter_code: '0'
-          iban_digits: '22'
-        - bank_country_code: "FI"
-          iban_letter_code: '0'
-          iban_digits: '16'
-        - bank_country_code: "FR"
-          iban_letter_code: '0'
-          iban_digits: '25'
-        - bank_country_code: "GB"
-          iban_letter_code: '4'
-          iban_digits: '14'
-        - bank_country_code: "GR"
-          iban_letter_code: '0'
-          iban_digits: '25'
-        - bank_country_code: "HU"
-          iban_letter_code: '0'
-          iban_digits: '28'
-        - bank_country_code: "HR"
-          iban_letter_code: '0'
-          iban_digits: '19'
-        - bank_country_code: "IE"
-          iban_letter_code: '4'
-          iban_digits: '16'
-        - bank_country_code: "IT"
-          iban_letter_code: '0'
-          iban_digits: '25'
-        - bank_country_code: "LV"
-          iban_letter_code: '4'
-          iban_digits: '15'
-        - bank_country_code: "LT"
-          iban_letter_code: '0'
-          iban_digits: '14'
-        - bank_country_code: "LU"
-          iban_letter_code: '0'
-          iban_digits: '16'
-        - bank_country_code: "PL"
-          iban_letter_code: '0'
-          iban_digits: '24'
-        - bank_country_code: "PT"
-          iban_letter_code: '0'
-          iban_digits: '18'
-        - bank_country_code: "MT"
-          iban_letter_code: '4'
-          iban_digits: '26'
-        - bank_country_code: "NL"
-          iban_letter_code: '4'
-          iban_digits: '12'
-        - bank_country_code: "RO"
-          iban_letter_code: '4'
-          iban_digits: '18'
-        - bank_country_code: "SE"
-          iban_letter_code: '0'
-          iban_digits: '22'
-        - bank_country_code: "SK"
-          iban_letter_code: '0'
-          iban_digits: '22'
+        at:
+          letter_code: '0'
+          digits: '18'
+        bg:
+          letter_code: '4'
+          digits: '14'
+        be:
+          letter_code: '0'
+          digits: '14'
+        cy:
+          letter_code: '0'
+          digits: '26'
+        cz:
+          letter_code: '0'
+          digits: '22'
+        de:
+          letter_code: '0'
+          digits: '20'
+        dk:
+          letter_code: '0'
+          digits: '16'
+        ee:
+          letter_code: '0'
+          digits: '18'
+        es:
+          letter_code: '0'
+          digits: '22'
+        fi:
+          letter_code: '0'
+          digits: '16'
+        fr:
+          letter_code: '0'
+          digits: '25'
+        gb:
+          letter_code: '4'
+          digits: '14'
+        gr:
+          letter_code: '0'
+          digits: '25'
+        hu:
+          letter_code: '0'
+          digits: '28'
+        hr:
+          letter_code: '0'
+          digits: '19'
+        ie:
+          letter_code: '4'
+          digits: '16'
+        it:
+          letter_code: '0'
+          digits: '25'
+        lv:
+          letter_code: '4'
+          digits: '15'
+        lt:
+          letter_code: '0'
+          digits: '14'
+        lu:
+          letter_code: '0'
+          digits: '16'
+        pl:
+          letter_code: '0'
+          digits: '24'
+        pt:
+          letter_code: '0'
+          digits: '18'
+        mt:
+          letter_code: '4'
+          digits: '26'
+        nl:
+          letter_code: '4'
+          digits: '12'
+        ro:
+          letter_code: '4'
+          digits: '18'
+        se:
+          letter_code: '0'
+          digits: '22'
+        sk:
+          letter_code: '0'
+          digits: '22'

--- a/test/test_faker_bank.rb
+++ b/test/test_faker_bank.rb
@@ -14,32 +14,110 @@ class TestFakerBank < Test::Unit::TestCase
     assert @tester.swift_bic.match(/(\w+\.? ?){2,3}/)
   end
 
-  def test_iban_default; assert @tester.iban.match(/[A-Z]{4}\d{14}/); end
-  def test_iban_at; assert @tester.iban("at").match(/\d{16}/); end
-  def test_iban_pl; assert @tester.iban("pl").match(/\d{8}[A-Z0-9]{16}/); end
-  def test_iban_be; assert @tester.iban("be").match(/\d{12}/); end
-  def test_iban_bg; assert @tester.iban("bg").match(/[A-Z]{4}\d{6}[A-Z0-9]{8}/); end
-  def test_iban_hr; assert @tester.iban("hr").match(/\d{17}/); end
-  def test_iban_cy; assert @tester.iban("cy").match(/\d{8}[A-Z0-9]{16}/); end
-  def test_iban_cz; assert @tester.iban("cz").match(/\d{20}/); end
-  def test_iban_dk; assert @tester.iban("dk").match(/\d{14}/); end
-  def test_iban_ee; assert @tester.iban("ee").match(/\d{16}/); end
-  def test_iban_fi; assert @tester.iban("fi").match(/\d{14}/); end
-  def test_iban_fr; assert @tester.iban("fr").match(/\d{10}[A-Z0-9]{11}\d{2}/); end
-  def test_iban_de; assert @tester.iban("de").match(/\d{18}/); end
-  def test_iban_gr; assert @tester.iban("gr").match(/\d{7}[A-Z0-9]{16}/); end
-  def test_iban_hu; assert @tester.iban("hu").match(/\d{24}/); end
-  def test_iban_ie; assert @tester.iban("ie").match(/[A-Z]{4}\d{14}/); end
-  def test_iban_it; assert @tester.iban("it").match(/[A-Z]\d{10}[A-Z0-9]{12}/); end
-  def test_iban_lv; assert @tester.iban("lv").match(/[A-Z]{4}[A-Z0-9]{13}/); end
-  def test_iban_lt; assert @tester.iban("lt").match(/\d{16}/); end
-  def test_iban_lu; assert @tester.iban("lu").match(/\d{3}[A-Z0-9]{13}/); end
-  def test_iban_mt; assert @tester.iban("mt").match(/[A-Z]{4}\d{5}[A-Z0-9]{18}/); end
-  def test_iban_nl; assert @tester.iban("nl").match(/[A-Z]{4}\d{10}/); end
-  def test_iban_ro; assert @tester.iban("ro").match(/[A-Z]{4}[A-Z0-9]{16}/); end
-  def test_iban_es; assert @tester.iban("es").match(/\d{20}/); end
-  def test_iban_se; assert @tester.iban("se").match(/\d{20}/); end
-  def test_iban_sk; assert @tester.iban("sk").match(/\d{24}/); end
+  def test_iban_default
+    assert @tester.iban.match(/[A-Z]{4}\d{14}/)
+  end
+
+  def test_iban_at
+    assert @tester.iban("at").match(/\d{16}/)
+  end
+
+  def test_iban_pl
+    assert @tester.iban("pl").match(/\d{8}[A-Z0-9]{16}/)
+  end
+
+  def test_iban_be
+    assert @tester.iban("be").match(/\d{12}/)
+  end
+
+  def test_iban_bg
+    assert @tester.iban("bg").match(/[A-Z]{4}\d{6}[A-Z0-9]{8}/)
+  end
+
+  def test_iban_hr
+    assert @tester.iban("hr").match(/\d{17}/)
+  end
+
+  def test_iban_cy
+    assert @tester.iban("cy").match(/\d{8}[A-Z0-9]{16}/)
+  end
+
+  def test_iban_cz
+    assert @tester.iban("cz").match(/\d{20}/)
+  end
+
+  def test_iban_dk
+    assert @tester.iban("dk").match(/\d{14}/)
+  end
+
+  def test_iban_ee
+    assert @tester.iban("ee").match(/\d{16}/)
+  end
+
+  def test_iban_fi
+    assert @tester.iban("fi").match(/\d{14}/)
+  end
+
+  def test_iban_fr
+    assert @tester.iban("fr").match(/\d{10}[A-Z0-9]{11}\d{2}/)
+  end
+
+  def test_iban_de
+    assert @tester.iban("de").match(/\d{18}/)
+  end
+
+  def test_iban_gr
+    assert @tester.iban("gr").match(/\d{7}[A-Z0-9]{16}/)
+  end
+
+  def test_iban_hu
+    assert @tester.iban("hu").match(/\d{24}/)
+  end
+
+  def test_iban_ie
+    assert @tester.iban("ie").match(/[A-Z]{4}\d{14}/)
+  end
+
+  def test_iban_it
+    assert @tester.iban("it").match(/[A-Z]\d{10}[A-Z0-9]{12}/)
+  end
+
+  def test_iban_lv
+    assert @tester.iban("lv").match(/[A-Z]{4}[A-Z0-9]{13}/)
+  end
+
+  def test_iban_lt
+    assert @tester.iban("lt").match(/\d{16}/)
+  end
+
+  def test_iban_lu
+    assert @tester.iban("lu").match(/\d{3}[A-Z0-9]{13}/)
+  end
+
+  def test_iban_mt
+    assert @tester.iban("mt").match(/[A-Z]{4}\d{5}[A-Z0-9]{18}/)
+  end
+
+  def test_iban_nl
+    assert @tester.iban("nl").match(/\ANL\d{2}\[A-Z]{4}\d{10}\z/)
+  end
+
+  def test_iban_ro
+    assert @tester.iban("ro").match(/[A-Z]{4}[A-Z0-9]{16}/)
+  end
+
+  def test_iban_es
+    assert @tester.iban("es").match(/\d{20}/)
+  end
+
+  def test_iban_se
+    assert @tester.iban("se").match(/\d{20}/)
+  end
+
+  def test_iban_sk
+    assert @tester.iban("sk").match(/\d{24}/)
+  end
+
 
   def test_iban_invalid
     assert_raise ArgumentError.new("Could not find iban details for bad") do


### PR DESCRIPTION
This method broke when loading in rails environment due to a difference in which
`Hash` keys were returned: `String` vs `Symbol`

This implementation avoids that problem by always calling `String` keys.

See: https://github.com/stympy/faker/pull/910 and https://github.com/stympy/faker/pull/916