### PR TITLE
Fallback translation without available locales enforcement

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.name        = "faker"
   s.version     = Faker::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Benjamin Curtis"]
-  s.email       = ["benjamin.curtis@gmail.com"]
+  s.author      = "Benjamin Curtis"
+  s.email       = "benjamin.curtis@gmail.com"
   s.homepage    = "https://github.com/stympy/faker"
   s.summary     = %q{Easily generate fake data}
   s.description = %q{Faker, a port of Data::Faker from Perl, is used to easily generate fake data: names, addresses, phone numbers, etc.}
@@ -15,6 +15,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('i18n', '~> 0.5')
   s.required_ruby_version = '>= 2.1'
 
-  s.files         = Dir['lib/**/*'] + %w(History.md License.txt CHANGELOG.md README.md)
-  s.require_paths = ["lib"]
+  s.files = Dir['lib/**/*'] + %w(
+    History.md
+    License.txt
+    CHANGELOG.md
+    CONTRIBUTING.md
+    README.md
+  )
 end

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -154,14 +154,19 @@ module Faker
         # Super-simple fallback -- fallback to en if the
         # translation was missing.  If the translation isn't
         # in en either, then it will raise again.
-        I18n.translate(*(args.push(opts)))
+        disable_enforce_available_locales do
+          I18n.translate(*(args.push(opts)))
+        end
       end
 
       # Executes block with given locale set.
       def with_locale(tmp_locale = nil)
         current_locale = Faker::Config.own_locale
         Faker::Config.locale = tmp_locale
-        I18n.with_locale(tmp_locale) { yield }
+
+        disable_enforce_available_locales do
+          I18n.with_locale(tmp_locale) { yield }
+        end
       ensure
         Faker::Config.locale = current_locale
       end
@@ -212,6 +217,14 @@ module Faker
         else
           0
         end
+      end
+
+      def disable_enforce_available_locales
+        old_enforce_available_locales = I18n.enforce_available_locales
+        I18n.enforce_available_locales = false
+        result = yield
+        I18n.enforce_available_locales = old_enforce_available_locales
+        result
       end
     end
   end

--- a/test/test_locale.rb
+++ b/test/test_locale.rb
@@ -35,6 +35,14 @@ class TestLocale < Test::Unit::TestCase
     assert_equal Faker::Base.translate('faker.separator'), LoadedYaml['en']['separator']
   end
 
+  def test_translation_fallback_without_en_in_available_locales
+    I18n.available_locales.delete(:en)
+    Faker::Config.locale = 'en-BORK'
+    assert_nil LoadedYaml['en-BORK']['name']
+    assert_equal Faker::Base.translate('faker.separator'), LoadedYaml['en']['separator']
+    I18n.available_locales << :en
+  end
+
   def test_regex
     Faker::Config.locale = 'en-GB'
     re = /[A-PR-UWYZ]([A-HK-Y][0-9][ABEHMNPRVWXY0-9]?|[0-9][ABCDEFGHJKPSTUW0-9]?) [0-9][ABD-HJLNP-UW-Z]{2}/


### PR DESCRIPTION
PR for #1030.

### Step to reproduce

```
> I18n.available_locales = [:es]
> Faker::Config.locale =  :es
> Faker::Base.translate('faker.separator')
`enforce_available_locales!': :en is not a valid locale (I18n::InvalidLocale)
```

We don't know how `I18n.enforce_available_locales` is set in application with `faker` on board. This config is global for the whole `I18n` module, that could be used as a dependency in other gems, e.g. `rails`. So I think we have to disable enforcing during fallbacks for those cases, when there is no `:en` locale in available locales list.

Solution feels a little bit hacky, so I'd like to open discussion on the better approach, that in my opinion will definitely lead to re-thinking locales organisation entirely. The main issue for just replacing `:en` with `I18n locale` everywhere is about violation `:en` ideomatic default for faker (it stores fallback values in `lib/locales/en`). It seems to me just renaming `en` to something fictive `default` or `faker` locale should separate language-region specific locales from default locale, particularly release `:en` locale from that burden.

P.S. I ❤️ `faker`, so I'd like to thank all people that stand by it ^_^ Any critics is desirable, because this is my first step here.