### PR TITLE
Fix usage document

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ gem 'faker', :git => 'git://github.com/stympy/faker.git', :branch => 'master'
 ## Usage
 
 ```ruby
-require `faker`
+require 'faker'
 
 Faker::Name.name      #=> "Christophe Bartell"
 


### PR DESCRIPTION
I read Usage and tried to do it on irb as follows.

```
irb(main):001:0> require `faker`
```

An error
```
Errno::ENOENT: No such file or directory - faker
	from (irb):1:in ``'
	from (irb):1
	from /Users/sashiyama/.rbenv/versions/2.4.1/bin/irb:11:in `<main>'
```