### PR TITLE
Bank: Start using regex for creating accounts and calculate valid checksum for IBAN

### DIFF
--- a/doc/bank.md
+++ b/doc/bank.md
@@ -6,6 +6,7 @@ Faker::Bank.swift_bic #=> "AAFMGB21"
 
 Faker::Bank.iban #=> "GB76DZJM33188515981979"
 
-# Optional argument bank_country_code(EU only)
+# Optional argument bank_country_code
+# All countries should be supported
 Faker::Bank.iban("be") #=> "BE6375388567752043"
 ```

--- a/lib/faker/bank.rb
+++ b/lib/faker/bank.rb
@@ -11,26 +11,38 @@ module Faker
         fetch('bank.swift_bic')
       end
 
-      def iban(country_code = "GB")
-        [
-          country_code.upcase,
-          Array.new(2) { rand(10) },
-          iban_range(country_code, :letter_code) { (65 + rand(26)).chr },
-          iban_range(country_code, :digits) { rand(10) }
-        ].join
+      def iban(country_code = 'GB')
+        # Each country has it's own format for bank accounts
+        # Many of them use letters in certain parts of the account
+        # Using regex patterns we can create virtually any type of bank account
+        begin
+          pattern = fetch("bank.iban_details.#{country_code.downcase}.bban_pattern")
+        rescue I18n::MissingTranslationData
+          raise ArgumentError, "Could not find iban details for #{country_code}"
+        end
+
+        # Use Faker::Base.regexify for creating a sample from bank account format regex
+        account = Base.regexify(/#{pattern}/)
+
+        # Add country code and checksum to the generated account to form valid IBAN
+        country_code.upcase + iban_checksum(country_code, account) + account
       end
 
       private
 
-      def iban_range(country_code, number_type)
-        array_length = iban_length(country_code, number_type)
-        Array.new(array_length) { yield }
-      end
+      # Calculates the mandatory checksum in 3rd and 4th characters in IBAN format
+      # source: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
+      def iban_checksum(country_code, account)
+        # Converts letters to numbers according the iban rules, A=10..Z=35
+        account_to_number = "#{account}#{country_code}00".upcase.chars.map { |d|
+           d.match(/[A-Z]/) ? (d.ord - 55).to_s : d
+        }.join.to_i
 
-      def iban_length(country_code, number_type)
-        fetch("bank.iban_details.#{country_code.downcase}.#{number_type}").to_i
-      rescue I18n::MissingTranslationData
-        raise ArgumentError, "Could not find iban details for #{country_code}"
+        # This is answer to (iban_to_num + checksum) % 97 == 1
+        checksum = ( 1 - account_to_number ) % 97
+
+        # Use leftpad to make the size always to 2
+        checksum.to_s.rjust(2, '0')
       end
     end
   end

--- a/lib/locales/en/bank.yml
+++ b/lib/locales/en/bank.yml
@@ -4,84 +4,276 @@ en:
       name: ["UBS CLEARING AND EXECUTION SERVICES LIMITED", "ABN AMRO CORPORATE FINANCE LIMITED", "ABN AMRO FUND MANAGERS LIMITED", "ABN AMRO HOARE GOVETT SECURITIES", "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD.", "ALKEN ASSET MANAGEMENT", "ALKEN ASSET MANAGEMENT", "ABN AMRO HOARE GOVETT LIMITED", "AAC CAPITAL PARTNERS LIMITED", "ABBOTSTONE AGRICULTURAL PROPERTY UNIT TRUST", "ABN AMRO QUOTED INVESTMENTS (UK) LIMITED", "ABN AMRO MEZZANINE (UK) LIMITED", "ABBEY LIFE", "SANTANDER UK PLC", "OTKRITIE SECURITIES LIMITED", "ABC INTERNATIONAL BANK PLC", "ALLIED BANK PHILIPPINES (UK) PLC", "ABU DHABI ISLAMIC BANK", "ABG SUNDAL COLLIER LIMITED", "PGMS (GLASGOW) LIMITED", "ABINGWORTH MANAGEMENT LIMITED", "THE ROYAL BANK OF SCOTLAND PLC (FORMER RBS NV)"]
       swift_bic: ["AACCGB21", "AACNGB21", "AAFMGB21", "AAHOGB21", "AAHVGB21", "AANLGB21", "AANLGB2L", "AAOGGB21", "AAPEGB21", "AAPUGB21", "AAQIGB21", "ABAZGB21", "ABBEGB21", "ABBYGB2L", "ABCCGB22", "ABCEGB2L", "ABCMGB21", "ABDIGB21", "ABECGB21", "ABFIGB21", "ABMNGB21", "ABNAGB21VOC" ]
       iban_details:
+        # Data from http://www.tbg5-finance.org/?ibandocs.shtml/
+        ad:
+          # Andorra
+          length: 24
+          bban_pattern: '\d{8}[A-Z0-9]{12}'
+        ae:
+          # United Arab Emirates
+          length: 23
+          bban_pattern: '\d{19}'
+        al:
+          # Albania
+          length: 28
+          bban_pattern: '\d{8}[A-Z0-9]{16}'
         at:
-          letter_code: '0'
-          digits: '18'
-        bg:
-          letter_code: '4'
-          digits: '14'
+          # Austria
+          length: 20
+          bban_pattern: '\d{16}'
+        az:
+          # Azerbaijan, Republic of
+          length: 28
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{20}'
+        ba:
+          # Bosnia
+          length: 20
+          bban_pattern: '\d{16}'
         be:
-          letter_code: '0'
-          digits: '14'
+          # Belgium
+          length: 16
+          bban_pattern: '\d{12}'
+        bg:
+          # Bulgaria
+          length: 22
+          bban_pattern: '[A-Z]{4}\d{6}[A-Z0-9]{8}'
+        bh:
+          # Bahrain
+          length: 22
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{14}'
+        br:
+          # Brazil
+          length: 29
+          bban_pattern: '[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}'
+        ch:
+          # Switzerland
+          length: 21
+          bban_pattern: '\d{5}[A-Z0-9]{12}'
+        cr:
+          # Costa Rica
+          length: 22
+          bban_pattern: '0\d{3}\d{14}'
         cy:
-          letter_code: '0'
-          digits: '26'
+          # Cyprus
+          length: 28
+          bban_pattern: '\d{8}[A-Z0-9]{16}'
         cz:
-          letter_code: '0'
-          digits: '22'
+          # Czech Republic
+          length: 24
+          bban_pattern: '\d{20}'
         de:
-          letter_code: '0'
-          digits: '20'
+          # Germany
+          length: 22
+          bban_pattern: '\d{18}'
         dk:
-          letter_code: '0'
-          digits: '16'
+          # Denmark
+          length: 18
+          bban_pattern: '\d{14}'
+        do:
+          # Dominican Republic
+          length: 28
+          bban_pattern: '[A-Z]{4}\d{20}'
         ee:
-          letter_code: '0'
-          digits: '18'
+          # Estonia
+          length: 20
+          bban_pattern: '\d{16}'
         es:
-          letter_code: '0'
-          digits: '22'
+          # Spain
+          length: 24
+          bban_pattern: '\d{20}'
         fi:
-          letter_code: '0'
-          digits: '16'
+          # Finland
+          length: 18
+          bban_pattern: '\d{14}'
+        fo:
+          # Faroe Islands
+          length: 18
+          bban_pattern: '\d{14}'
         fr:
-          letter_code: '0'
-          digits: '25'
+          # France
+          length: 27
+          bban_pattern: '\d{10}[A-Z0-9]{11}\d{2}'
         gb:
-          letter_code: '4'
-          digits: '14'
+          # United Kingdom
+          length: 22
+          bban_pattern: '[A-Z]{4}\d{14}'
+        ge:
+          # Georgia
+          length: 22
+          bban_pattern: '[A-Z]{2}\d{16}'
+        gi:
+          # Gibraltar
+          length: 23
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{15}'
+        gl:
+          # Greenland
+          length: 18
+          bban_pattern: '\d{14}'
         gr:
-          letter_code: '0'
-          digits: '25'
-        hu:
-          letter_code: '0'
-          digits: '28'
+          # Greece
+          length: 27
+          bban_pattern: '\d{7}[A-Z0-9]{16}'
+        gt:
+          # Guatemala
+          length: 28
+          bban_pattern: '[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}'
         hr:
-          letter_code: '0'
-          digits: '19'
+          # Croatia
+          length: 21
+          bban_pattern: '\d{17}'
+        hu:
+          # Hungary
+          length: 28
+          bban_pattern: '\d{24}'
         ie:
-          letter_code: '4'
-          digits: '16'
+          # Ireland
+          length: 22
+          bban_pattern: '[A-Z]{4}\d{14}'
+        il:
+          # Israel
+          length: 23
+          bban_pattern: '\d{19}'
+        is:
+          # Iceland
+          length: 26
+          bban_pattern: '\d{22}'
         it:
-          letter_code: '0'
-          digits: '25'
-        lv:
-          letter_code: '4'
-          digits: '15'
+          # Italy
+          length: 27
+          bban_pattern: '[A-Z]\d{10}[A-Z0-9]{12}'
+        kw:
+          # Kuwait
+          length: 30
+          bban_pattern: '[A-Z]{4}\d{22}'
+        kz:
+          # Kazakhstan
+          length: 20
+          bban_pattern: '[0-9]{3}[A-Z0-9]{13}'
+        lb:
+          # Lebanon
+          length: 28
+          bban_pattern: '\d{4}[A-Z0-9]{20}'
+        li:
+          # Liechtenstein
+          length: 21
+          bban_pattern: '\d{5}[A-Z0-9]{12}'
         lt:
-          letter_code: '0'
-          digits: '14'
+          # Lithuania
+          length: 20
+          bban_pattern: '\d{16}'
         lu:
-          letter_code: '0'
-          digits: '16'
-        pl:
-          letter_code: '0'
-          digits: '24'
-        pt:
-          letter_code: '0'
-          digits: '18'
+          # Luxembourg
+          length: 20
+          bban_pattern: '\d{3}[A-Z0-9]{13}'
+        lv:
+          # Latvia
+          length: 21
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{13}'
+        mc:
+          # Monaco
+          length: 27
+          bban_pattern: '\d{10}[A-Z0-9]{11}\d{2}'
+        md:
+          # Moldova
+          length: 24
+          bban_pattern: '[A-Z]{2}[A-Z0-9]{18}'
+        me:
+          # Montenegro
+          length: 22
+          bban_pattern: '\d{18}'
+        mk:
+          # Macedonia
+          length: 19
+          bban_pattern: '\d{3}[A-Z0-9]{10}\d{2}'
+        mr:
+          # Mauritania
+          length: 27
+          bban_pattern: '\d{23}'
         mt:
-          letter_code: '4'
-          digits: '26'
+          # Malta
+          length: 31
+          bban_pattern: '[A-Z]{4}\d{5}[A-Z0-9]{18}'
+        mu:
+          # Mauritius
+          length: 30
+          bban_pattern: '[A-Z]{4}\d{19}[A-Z]{3}'
         nl:
-          letter_code: '4'
-          digits: '10'
+          # Netherlands
+          length: 18
+          bban_pattern: '[A-Z]{4}\d{10}'
+        'no':
+          # Norway
+          length: 15
+          bban_pattern: '\d{11}'
+        pk:
+          # Pakistan
+          length: 24
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{16}'
+        pl:
+          # Poland
+          length: 28
+          bban_pattern: '\d{8}[A-Z0-9]{16}'
+        ps:
+          # Palestinian Territory, Occupied
+          length: 29
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{21}'
+        pt:
+          # Portugal
+          length: 25
+          bban_pattern: '\d{21}'
+        qa:
+          # Qatar
+          length: 29
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{21}'
         ro:
-          letter_code: '4'
-          digits: '18'
+          # Romania
+          length: 24
+          bban_pattern: '[A-Z]{4}[A-Z0-9]{16}'
+        rs:
+          # Serbia
+          length: 22
+          bban_pattern: '\d{18}'
+        sa:
+          # Saudi Arabia
+          length: 24
+          bban_pattern: '\d{2}[A-Z0-9]{18}'
         se:
-          letter_code: '0'
-          digits: '22'
+          # Sweden
+          length: 24
+          bban_pattern: '\d{20}'
+        si:
+          # Slovenia
+          length: 19
+          bban_pattern: '\d{15}'
         sk:
-          letter_code: '0'
-          digits: '22'
+          # Slovakia
+          length: 24
+          bban_pattern: '\d{20}'
+        sm:
+          # San Marino
+          length: 27
+          bban_pattern: '[A-Z]\d{10}[A-Z0-9]{12}'
+        tl:
+          # Timor-Leste
+          length: 23
+          bban_pattern: '\d{19}'
+        tn:
+          # Tunisia
+          length: 24
+          bban_pattern: '\d{20}'
+        tr:
+          # Turkey
+          length: 26
+          bban_pattern: '\d{5}[A-Z0-9]{17}'
+        ua:
+          # Ukraine
+          length: 29
+          bban_pattern: '\d{25}'
+        vg:
+          # Virgin Islands, British
+          length: 24
+          bban_pattern: '[A-Z]{4}\d{16}'
+        xk:
+          # Kosovo, Republic of
+          length: 20
+          bban_pattern: '\d{16}'

--- a/lib/locales/en/bank.yml
+++ b/lib/locales/en/bank.yml
@@ -1,4 +1,4 @@
-# Most of these details and the idea were copied from: https://github.com/iulianu/iban-tools
+# Most of the iban details and the idea were copied from: https://github.com/iulianu/iban-tools
 #
 # Copyright (c) 2009 Iulian Dogariu
 #

--- a/lib/locales/en/bank.yml
+++ b/lib/locales/en/bank.yml
@@ -1,3 +1,26 @@
+# Most of these details and the idea were copied from: https://github.com/iulianu/iban-tools
+#
+# Copyright (c) 2009 Iulian Dogariu
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 en:
   faker:
     bank:

--- a/test/test_faker_bank.rb
+++ b/test/test_faker_bank.rb
@@ -2,6 +2,8 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
 class TestFakerBank < Test::Unit::TestCase
 
+  IBAN_HEADER = '[A-Z]{2}[0-9]{2}'
+
   def setup
     @tester = Faker::Bank
   end
@@ -18,106 +20,482 @@ class TestFakerBank < Test::Unit::TestCase
     assert @tester.iban.match(/[A-Z]{4}\d{14}/)
   end
 
+  # Andorra
+  def test_iban_ad
+    account = @tester.iban('ad')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{12}$/)
+  end
+
+  # United Arab Emirates
+  def test_iban_ae
+    account = @tester.iban('ae')
+    assert account.length == 23
+    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+  end
+
+  # Albania
+  def test_iban_al
+    account = @tester.iban('al')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
+  end
+
+  # Austria
   def test_iban_at
-    assert @tester.iban("at").match(/\d{16}/)
+    account = @tester.iban('at')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
   end
 
-  def test_iban_pl
-    assert @tester.iban("pl").match(/\d{8}[A-Z0-9]{16}/)
+  # Azerbaijan, Republic of
+  def test_iban_az
+    account = @tester.iban('az')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{20}$/)
   end
 
+  # Bosnia
+  def test_iban_ba
+    account = @tester.iban('ba')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+  end
+
+  # Belgium
   def test_iban_be
-    assert @tester.iban("be").match(/\d{12}/)
+    account = @tester.iban('be')
+    assert account.length == 16
+    assert account.match(/^#{IBAN_HEADER}\d{12}$/)
   end
 
+  # Bulgaria
   def test_iban_bg
-    assert @tester.iban("bg").match(/[A-Z]{4}\d{6}[A-Z0-9]{8}/)
+    account = @tester.iban('bg')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{6}[A-Z0-9]{8}$/)
   end
 
-  def test_iban_hr
-    assert @tester.iban("hr").match(/\d{17}/)
+  # Bahrain
+  def test_iban_bh
+    account = @tester.iban('bh')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{14}$/)
   end
 
+  # Brazil
+  def test_iban_br
+    account = @tester.iban('br')
+    assert account.length == 29
+    assert account.match(/^#{IBAN_HEADER}[0-9]{8}[0-9]{5}[0-9]{10}[A-Z]{1}[A-Z0-9]{1}$/)
+  end
+
+  # Switzerland
+  def test_iban_ch
+    account = @tester.iban('ch')
+    assert account.length == 21
+    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
+  end
+
+  # Costa Rica
+  def test_iban_cr
+    account = @tester.iban('cr')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}0\d{3}\d{14}$/)
+  end
+
+  # Cyprus
   def test_iban_cy
-    assert @tester.iban("cy").match(/\d{8}[A-Z0-9]{16}/)
+    account = @tester.iban('cy')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
   end
 
+  # Czech Republic
   def test_iban_cz
-    assert @tester.iban("cz").match(/\d{20}/)
+    account = @tester.iban('cz')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
   end
 
-  def test_iban_dk
-    assert @tester.iban("dk").match(/\d{14}/)
-  end
-
-  def test_iban_ee
-    assert @tester.iban("ee").match(/\d{16}/)
-  end
-
-  def test_iban_fi
-    assert @tester.iban("fi").match(/\d{14}/)
-  end
-
-  def test_iban_fr
-    assert @tester.iban("fr").match(/\d{10}[A-Z0-9]{11}\d{2}/)
-  end
-
+  # Germany
   def test_iban_de
-    assert @tester.iban("de").match(/\d{18}/)
+    account = @tester.iban('de')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
   end
 
-  def test_iban_gr
-    assert @tester.iban("gr").match(/\d{7}[A-Z0-9]{16}/)
+  # Denmark
+  def test_iban_dk
+    account = @tester.iban('dk')
+    assert account.length == 18
+    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
   end
 
-  def test_iban_hu
-    assert @tester.iban("hu").match(/\d{24}/)
+  # Dominican Republic
+  def test_iban_do
+    account = @tester.iban('do')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{20}$/)
   end
 
-  def test_iban_ie
-    assert @tester.iban("ie").match(/[A-Z]{4}\d{14}/)
+  # Estonia
+  def test_iban_ee
+    account = @tester.iban('ee')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
   end
 
-  def test_iban_it
-    assert @tester.iban("it").match(/[A-Z]\d{10}[A-Z0-9]{12}/)
-  end
-
-  def test_iban_lv
-    assert @tester.iban("lv").match(/[A-Z]{4}[A-Z0-9]{13}/)
-  end
-
-  def test_iban_lt
-    assert @tester.iban("lt").match(/\d{16}/)
-  end
-
-  def test_iban_lu
-    assert @tester.iban("lu").match(/\d{3}[A-Z0-9]{13}/)
-  end
-
-  def test_iban_mt
-    assert @tester.iban("mt").match(/[A-Z]{4}\d{5}[A-Z0-9]{18}/)
-  end
-
-  def test_iban_nl
-    assert @tester.iban("nl").match(/\ANL\d{2}[A-Z]{4}\d{10}\z/)
-  end
-
-  def test_iban_ro
-    assert @tester.iban("ro").match(/[A-Z]{4}[A-Z0-9]{16}/)
-  end
-
+  # Spain
   def test_iban_es
-    assert @tester.iban("es").match(/\d{20}/)
+    account = @tester.iban('es')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
   end
 
+  # Finland
+  def test_iban_fi
+    account = @tester.iban('fi')
+    assert account.length == 18
+    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+  end
+
+  # Faroe Islands
+  def test_iban_fo
+    account = @tester.iban('fo')
+    assert account.length == 18
+    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+  end
+
+  # France
+  def test_iban_fr
+    account = @tester.iban('fr')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
+  end
+
+  # United Kingdom
+  def test_iban_gb
+    account = @tester.iban('gb')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
+  end
+
+  # Georgia
+  def test_iban_ge
+    account = @tester.iban('ge')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{2}\d{16}$/)
+  end
+
+  # Gibraltar
+  def test_iban_gi
+    account = @tester.iban('gi')
+    assert account.length == 23
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{15}$/)
+  end
+
+  # Greenland
+  def test_iban_gl
+    account = @tester.iban('gl')
+    assert account.length == 18
+    assert account.match(/^#{IBAN_HEADER}\d{14}$/)
+  end
+
+  # Greece
+  def test_iban_gr
+    account = @tester.iban('gr')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}\d{7}[A-Z0-9]{16}$/)
+  end
+
+  # Guatemala
+  def test_iban_gt
+    account = @tester.iban('gt')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}[A-Z0-9]{4}\d{2}\d{2}[A-Z0-9]{16}$/)
+  end
+
+  # Croatia
+  def test_iban_hr
+    account = @tester.iban('hr')
+    assert account.length == 21
+    assert account.match(/^#{IBAN_HEADER}\d{17}$/)
+  end
+
+  # Hungary
+  def test_iban_hu
+    account = @tester.iban('hu')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}\d{24}$/)
+  end
+
+  # Ireland
+  def test_iban_ie
+    account = @tester.iban('ie')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{14}$/)
+  end
+
+  # Israel
+  def test_iban_il
+    account = @tester.iban('il')
+    assert account.length == 23
+    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+  end
+
+  # Iceland
+  def test_iban_is
+    account = @tester.iban('is')
+    assert account.length == 26
+    assert account.match(/^#{IBAN_HEADER}\d{22}$/)
+  end
+
+  # Italy
+  def test_iban_it
+    account = @tester.iban('it')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
+  end
+
+  # Kuwait
+  def test_iban_kw
+    account = @tester.iban('kw')
+    assert account.length == 30
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{22}$/)
+  end
+
+  # Kazakhstan
+  def test_iban_kz
+    account = @tester.iban('kz')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}[0-9]{3}[A-Z0-9]{13}$/)
+  end
+
+  # Lebanon
+  def test_iban_lb
+    account = @tester.iban('lb')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}\d{4}[A-Z0-9]{20}$/)
+  end
+
+  # Liechtenstein
+  def test_iban_li
+    account = @tester.iban('li')
+    assert account.length == 21
+    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{12}$/)
+  end
+
+  # Lithuania
+  def test_iban_lt
+    account = @tester.iban('lt')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+  end
+
+  # Luxembourg
+  def test_iban_lu
+    account = @tester.iban('lu')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{13}$/)
+  end
+
+  # Latvia
+  def test_iban_lv
+    account = @tester.iban('lv')
+    assert account.length == 21
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{13}$/)
+  end
+
+  # Monaco
+  def test_iban_mc
+    account = @tester.iban('mc')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}\d{10}[A-Z0-9]{11}\d{2}$/)
+  end
+
+  # Moldova
+  def test_iban_md
+    account = @tester.iban('md')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{2}[A-Z0-9]{18}$/)
+  end
+
+  # Montenegro
+  def test_iban_me
+    account = @tester.iban('me')
+
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
+  end
+
+  # Macedonia
+  def test_iban_mk
+    account = @tester.iban('mk')
+    assert account.length == 19
+    assert account.match(/^#{IBAN_HEADER}\d{3}[A-Z0-9]{10}\d{2}$/)
+  end
+
+  # Mauritania
+  def test_iban_mr
+    account = @tester.iban('mr')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}\d{23}$/)
+  end
+
+  # Malta
+  def test_iban_mt
+    account = @tester.iban('mt')
+    assert account.length == 31
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{5}[A-Z0-9]{18}$/)
+  end
+
+  # Mauritius
+  def test_iban_mu
+    account = @tester.iban('mu')
+    assert account.length == 30
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{19}[A-Z]{3}$/)
+  end
+
+  # Netherlands
+  def test_iban_nl
+    account = @tester.iban('nl')
+    assert account.length == 18
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{10}$/)
+  end
+
+  # Norway
+  def test_iban_no
+    account = @tester.iban('no')
+    assert account.length == 15
+    assert account.match(/^#{IBAN_HEADER}\d{11}$/)
+  end
+
+  # Pakistan
+  def test_iban_pk
+    account = @tester.iban('pk')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
+  end
+
+  # Poland
+  def test_iban_pl
+    account = @tester.iban('pl')
+    assert account.length == 28
+    assert account.match(/^#{IBAN_HEADER}\d{8}[A-Z0-9]{16}$/)
+  end
+
+  # Palestinian Territory, Occupied
+  def test_iban_ps
+    account = @tester.iban('ps')
+    assert account.length == 29
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
+  end
+
+  # Portugal
+  def test_iban_pt
+    account = @tester.iban('pt')
+    assert account.length == 25
+    assert account.match(/^#{IBAN_HEADER}\d{21}$/)
+  end
+
+  # Qatar
+  def test_iban_qa
+    account = @tester.iban('qa')
+    assert account.length == 29
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{21}$/)
+  end
+
+  # Romania
+  def test_iban_ro
+    account = @tester.iban('ro')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}[A-Z0-9]{16}$/)
+  end
+
+  # Serbia
+  def test_iban_rs
+    account = @tester.iban('rs')
+    assert account.length == 22
+    assert account.match(/^#{IBAN_HEADER}\d{18}$/)
+  end
+
+  # Saudi Arabia
+  def test_iban_sa
+    account = @tester.iban('sa')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{2}[A-Z0-9]{18}$/)
+  end
+
+  # Sweden
   def test_iban_se
-    assert @tester.iban("se").match(/\d{20}/)
+    account = @tester.iban('se')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
   end
 
+  # Slovenia
+  def test_iban_si
+    account = @tester.iban('si')
+    assert account.length == 19
+    assert account.match(/^#{IBAN_HEADER}\d{15}$/)
+  end
+
+  # Slovakia
   def test_iban_sk
-    assert @tester.iban("sk").match(/\d{24}/)
+    account = @tester.iban('sk')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
   end
 
+  # San Marino
+  def test_iban_sm
+    account = @tester.iban('sm')
+    assert account.length == 27
+    assert account.match(/^#{IBAN_HEADER}[A-Z]\d{10}[A-Z0-9]{12}$/)
+  end
+
+  # Timor-Leste
+  def test_iban_tl
+    account = @tester.iban('tl')
+    assert account.length == 23
+    assert account.match(/^#{IBAN_HEADER}\d{19}$/)
+  end
+
+  # Tunisia
+  def test_iban_tn
+    account = @tester.iban('tn')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}\d{20}$/)
+  end
+
+  # Turkey
+  def test_iban_tr
+    account = @tester.iban('tr')
+    assert account.length == 26
+    assert account.match(/^#{IBAN_HEADER}\d{5}[A-Z0-9]{17}$/)
+  end
+
+  # Ukraine
+  def test_iban_ua
+    account = @tester.iban('ua')
+    assert account.length == 29
+    assert account.match(/^#{IBAN_HEADER}\d{25}$/)
+  end
+
+  # Virgin Islands, British
+  def test_iban_vg
+    account = @tester.iban('vg')
+    assert account.length == 24
+    assert account.match(/^#{IBAN_HEADER}[A-Z]{4}\d{16}$/)
+  end
+
+  # Kosovo, Republic of
+  def test_iban_xk
+    account = @tester.iban('xk')
+    assert account.length == 20
+    assert account.match(/^#{IBAN_HEADER}\d{16}$/)
+  end
 
   def test_iban_invalid
     assert_raise ArgumentError.new("Could not find iban details for bad") do


### PR DESCRIPTION
This change allows us to create IBAN accounts which pass at least the IBAN validity check.

I changed the logic for the creation to use regex instead since we have the excellent
`Faker::Base.regexify()`.

Also many bank account were just wrong before this because they had wrong length.