### PR TITLE
Stripe

### DIFF
--- a/doc/dune.md
+++ b/doc/dune.md
@@ -5,8 +5,8 @@
 Faker::Dune.character #=> "Leto Atreides"
 Faker::Dune.title #=> "Duke"
 Faker::Dune.planet #=> "Caladan"
-Faker::Dune.quotes #=> "A dead man, surely, no longer requires that water."
-Faker::Dune.quotes("baron_harkonnen") #=> "He who controls the spice, controls the universe!"
+Faker::Dune.quote #=> "A dead man, surely, no longer requires that water."
+Faker::Dune.quote("baron_harkonnen") #=> "He who controls the spice, controls the universe!"
 Faker::Dune.sayings #=> "You do not beg the sun for mercy."
 Faker::Dune.sayings("fremen") #=> "May thy knife chip and shatter."
 ```

--- a/doc/stripe.md
+++ b/doc/stripe.md
@@ -12,6 +12,11 @@ Faker::Stripe.invalid_card #=> 4000000000000002
 
 Faker::Stripe.invalid_card("addressZipFail") #=> 4000000000000010
 
+Faker::Stripe.valid_card_object #=>  {type:   "american express",
+                                #     number: "378282246310005",
+                                #     exp_mo: 10,
+                                #     exp_yr: 2018,
+                                #     ccv:    1234}
 ```
 
 ProTip:

--- a/doc/stripe.md
+++ b/doc/stripe.md
@@ -12,11 +12,13 @@ Faker::Stripe.invalid_card #=> 4000000000000002
 
 Faker::Stripe.invalid_card("addressZipFail") #=> 4000000000000010
 
-Faker::Stripe.valid_card_object #=>  {type:   "american express",
-                                #     number: "378282246310005",
-                                #     exp_mo: 10,
-                                #     exp_yr: 2018,
-                                #     ccv:    1234}
+Faker::Stripe.valid_month #=> "10"
+
+Faker::Stripe.valid_year #=> "18"
+
+Faker::Stripe.valid_ccv #=> 123
+
+Faker::Stripe.valid_amex_ccv #=> 1234
 ```
 
 ProTip:

--- a/doc/stripe.md
+++ b/doc/stripe.md
@@ -16,7 +16,7 @@ Faker::Stripe.card_error #=> "4000000000000002"
 
 ProTip:
 
-For Stripe email and charge amount, use:
+For Stripe charge amount and email:
 
 ```ruby
 Faker::Number.between(3,10) #=> 100

--- a/doc/stripe.md
+++ b/doc/stripe.md
@@ -4,19 +4,18 @@
 
 
 ```ruby
-Faker::Stripe.valid_card #=> "4242424242424242"
+Faker::Stripe.valid_card #=> 4242424242424242
 
-Faker::Stripe.valid_card("visa_debit") #=> "4000056655665556"
+Faker::Stripe.valid_card("visa_debit") #=> 4000056655665556
 
-Faker::Stripe.valid_us_token #=> "tok_mastercard"
+Faker::Stripe.invalid_card #=> 4000000000000002
 
-Faker::Stripe.card_error #=> "4000000000000002"
+Faker::Stripe.invalid_card("addressZipFail") #=> 4000000000000010
 
 ```
 
 ProTip:
-
-For Stripe charge amount and email:
+Use some of the other handy Faker classes for Stripe charge amounts and email.
 
 ```ruby
 Faker::Number.between(3,10) #=> 100

--- a/doc/stripe.md
+++ b/doc/stripe.md
@@ -1,0 +1,25 @@
+# Faker::Stripe
+
+### Test Stripe transactions without hardcoding card numbers and tokens
+
+
+```ruby
+Faker::Stripe.valid_card #=> "4242424242424242"
+
+Faker::Stripe.valid_card("visa_debit") #=> "4000056655665556"
+
+Faker::Stripe.valid_us_token #=> "tok_mastercard"
+
+Faker::Stripe.card_error #=> "4000000000000002"
+
+```
+
+ProTip:
+
+For Stripe email and charge amount, use:
+
+```ruby
+Faker::Number.between(3,10) #=> 100
+
+Faker::Internet.free_email #=> "freddy@gmail.com"
+```

--- a/lib/faker/stripe.rb
+++ b/lib/faker/stripe.rb
@@ -5,10 +5,8 @@ module Faker
         valid_cards = translate('faker.stripe.valid_cards').keys
 
         if card_type.nil?
-          card_type = sample(valid_cards)
+          card_type = sample(valid_cards).to_s
         else
-          card_type.to_s.downcase!
-
           unless valid_cards.include?(card_type.to_sym)
             raise ArgumentError,
               "Valid credit cards argument can be left blank or include #{valid_cards.join(', ')}"
@@ -22,10 +20,8 @@ module Faker
         invalid_cards = translate('faker.stripe.invalid_cards').keys
 
         if card_error.nil?
-          card_error = sample(valid_cards)
+          card_error = sample(invalid_cards).to_s
         else
-          card_error.to_s.downcase!
-
           unless invalid_cards.include?(card_error.to_sym)
             raise ArgumentError,
               "Invalid credit cards argument can be left blank or include #{invalid_cards.join(', ')}"

--- a/lib/faker/stripe.rb
+++ b/lib/faker/stripe.rb
@@ -31,9 +31,21 @@ module Faker
         return fetch('stripe.invalid_cards.' + card_error)
       end
 
-      def valid_card_object
-        sample('stripe.valid_card_objects')
+      def valid_month
+        fetch('stripe.valid_exp_mo')
       end
+
+      def valid_year
+        fetch('stripe.valid_exp_yr')
+      end
+
+      def valid_ccv
+        fetch('stripe.valid_ccv')
+      end
+
+      def valid_amex_ccv
+        fetch('stripe.valid_amex_ccv')
+      end      
 
     end
   end

--- a/lib/faker/stripe.rb
+++ b/lib/faker/stripe.rb
@@ -1,0 +1,41 @@
+module Faker
+  class Stripe < Base
+    class << self
+      def valid_card(card_type = nil)
+        valid_cards = translate('faker.stripe.valid_cards').keys
+
+        if card_type.nil?
+          card_type = sample(valid_cards)
+        else
+          card_type.to_s.downcase!
+
+          unless valid_cards.include?(card_type.to_sym)
+            raise ArgumentError,
+              "Valid credit cards argument can be left blank or include #{valid_cards.join(', ')}"
+          end
+        end
+
+        return fetch('stripe.valid_cards.' + card_type)
+      end
+
+      def invalid_card(card_error = nil)
+        invalid_cards = translate('faker.stripe.invalid_cards').keys
+
+        if card_error.nil?
+          card_error = sample(valid_cards)
+        else
+          card_error.to_s.downcase!
+
+          unless invalid_cards.include?(card_error.to_sym)
+            raise ArgumentError,
+              "Invalid credit cards argument can be left blank or include #{invalid_cards.join(', ')}"
+          end
+        end
+
+        return fetch('stripe.invalid_cards.' + card_error)
+      end
+
+
+    end
+  end
+end

--- a/lib/faker/stripe.rb
+++ b/lib/faker/stripe.rb
@@ -31,6 +31,9 @@ module Faker
         return fetch('stripe.invalid_cards.' + card_error)
       end
 
+      def valid_card_object
+        sample('stripe.valid_card_objects')
+      end
 
     end
   end

--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -2,31 +2,62 @@ en:
   faker:
     stripe:
       valid_cards:
-        visa: "4242424242424242"
-        visa_debit: "4000056655665556"
-        mc: "5555555555554444"
-        mc_2_series: "2223003122003222"
-        mc_debit: "5200828282828210"
-        mc_prepaid: "5105105105105100"
-        amex: "378282246310005"
-        amex_2: "371449635398431"
-        discover: "6011111111111117"
-        discover_2: "6011000990139424"
-        diners_club: "30569309025904"
+        visa:          "4242424242424242"
+        visa_debit:    "4000056655665556"
+        mc:            "5555555555554444"
+        mc_2_series:   "2223003122003222"
+        mc_debit:      "5200828282828210"
+        mc_prepaid:    "5105105105105100"
+        amex:          "378282246310005"
+        amex_2:        "371449635398431"
+        discover:      "6011111111111117"
+        discover_2:    "6011000990139424"
+        diners_club:   "30569309025904"
         diners_club_2: "38520000023237"
-        jcb: "3530111333300000"
+        jcb:           "3530111333300000"
       invalid_cards:
-        addressZipFail: "4000000000000010"  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressFail: "4000000000000028"  # Charge succeeds but the address_line1_check verification fails.
-        zipFail: "4000000000000036"  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressZipUnavailable: "4000000000000044"  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
-        cvcFail: "4000000000000101"  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
-        customerChargeFail: "4000000000000341"  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
-        successWithReview: "4000000000009235"  # Charge succeeds with a risk_level of elevated and placed into review.
-        declineCard: "4000000000000002"  # Charge is declined with a card_declined code.
-        declineFraudulentCard: "4100000000000019"  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
-        declineIncorrectCvc: "4000000000000127"  # Charge is declined with an incorrect_cvc code.
-        declineExpired: "4000000000000069"  # Charge is declined with an expired_card code.
+        addressZipFail:         "4000000000000010"  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressFail:            "4000000000000028"  # Charge succeeds but the address_line1_check verification fails.
+        zipFail:                "4000000000000036"  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressZipUnavailable:  "4000000000000044"  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
+        cvcFail:                "4000000000000101"  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
+        customerChargeFail:     "4000000000000341"  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
+        successWithReview:      "4000000000009235"  # Charge succeeds with a risk_level of elevated and placed into review.
+        declineCard:            "4000000000000002"  # Charge is declined with a card_declined code.
+        declineFraudulentCard:  "4100000000000019"  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
+        declineIncorrectCvc:    "4000000000000127"  # Charge is declined with an incorrect_cvc code.
+        declineExpired:         "4000000000000069"  # Charge is declined with an expired_card code.
         declineProcessingError: "4000000000000119"  # Charge is declined with a processing_error code.
         declineIncorrectNumber: "4242424242424241"  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.
+      valid_card_objects:
+        - type:   "visa"
+          number: "#{valid_cards.visa}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(3)}"
+        - type:   "mastercard"
+          number: "#{valid_cards.mc}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(3)}"
+        - type:   "american express"
+          number: "#{valid_cards.amex}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(4)}"
+        - type:   "discover"
+          number: "#{valid_cards.discover}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(3)}"
+        - type:   "diners_club"
+          number: "#{valid_cards.diners_club}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(3)}"
+        - type:   "jcb"
+          number: "#{valid_cards.jcb}"
+          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
+          ccv:    "#{Faker::Number.number(3)}"
 # https://stripe.com/docs/testing

--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -1,0 +1,32 @@
+en:
+  faker:
+    stripe:
+      valid_cards:
+        visa: 4242424242424242
+        visa_debit: 4000056655665556
+        mc: 5555555555554444
+        mc_2_series: 2223003122003222
+        mc_debit: 5200828282828210
+        mc_prepaid: 5105105105105100
+        amex: 378282246310005
+        amex_2: 371449635398431
+        discover: 6011111111111117
+        discover_2: 6011000990139424
+        diners_club: 30569309025904
+        diners_club_2: 38520000023237
+        jcb: 3530111333300000
+      invalid_cards:
+        addressZipFail: 4000000000000010  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressFail: 4000000000000028  # Charge succeeds but the address_line1_check verification fails.
+        zipFail: 4000000000000036  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressZipUnavailable: 4000000000000044  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
+        cvcFail: 4000000000000101  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
+        customerChargeFail: 4000000000000341  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
+        successWithReview: 4000000000009235  # Charge succeeds with a risk_level of elevated and placed into review.
+        declineCard: 4000000000000002  # Charge is declined with a card_declined code.
+        declineFraudulentCard: 4100000000000019  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
+        declineIncorrectCvc: 4000000000000127  # Charge is declined with an incorrect_cvc code.
+        declineExpired: 4000000000000069  # Charge is declined with an expired_card code.
+        declineProcessingError: 4000000000000119  # Charge is declined with a processing_error code.
+        declineIncorrectNumber: 4242424242424241  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.
+# https://stripe.com/docs/testing

--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -2,31 +2,31 @@ en:
   faker:
     stripe:
       valid_cards:
-        visa: 4242424242424242
-        visa_debit: 4000056655665556
-        mc: 5555555555554444
-        mc_2_series: 2223003122003222
-        mc_debit: 5200828282828210
-        mc_prepaid: 5105105105105100
-        amex: 378282246310005
-        amex_2: 371449635398431
-        discover: 6011111111111117
-        discover_2: 6011000990139424
-        diners_club: 30569309025904
-        diners_club_2: 38520000023237
-        jcb: 3530111333300000
+        visa: "4242424242424242"
+        visa_debit: "4000056655665556"
+        mc: "5555555555554444"
+        mc_2_series: "2223003122003222"
+        mc_debit: "5200828282828210"
+        mc_prepaid: "5105105105105100"
+        amex: "378282246310005"
+        amex_2: "371449635398431"
+        discover: "6011111111111117"
+        discover_2: "6011000990139424"
+        diners_club: "30569309025904"
+        diners_club_2: "38520000023237"
+        jcb: "3530111333300000"
       invalid_cards:
-        addressZipFail: 4000000000000010  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressFail: 4000000000000028  # Charge succeeds but the address_line1_check verification fails.
-        zipFail: 4000000000000036  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
-        addressZipUnavailable: 4000000000000044  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
-        cvcFail: 4000000000000101  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
-        customerChargeFail: 4000000000000341  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
-        successWithReview: 4000000000009235  # Charge succeeds with a risk_level of elevated and placed into review.
-        declineCard: 4000000000000002  # Charge is declined with a card_declined code.
-        declineFraudulentCard: 4100000000000019  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
-        declineIncorrectCvc: 4000000000000127  # Charge is declined with an incorrect_cvc code.
-        declineExpired: 4000000000000069  # Charge is declined with an expired_card code.
-        declineProcessingError: 4000000000000119  # Charge is declined with a processing_error code.
-        declineIncorrectNumber: 4242424242424241  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.
+        addressZipFail: "4000000000000010"  # The address_line1_check and address_zip_check verifications fail. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressFail: "4000000000000028"  # Charge succeeds but the address_line1_check verification fails.
+        zipFail: "4000000000000036"  # The address_zip_check verification fails. If your account is blocking payments that fail ZIP code validation, the charge is declined.
+        addressZipUnavailable: "4000000000000044"  # Charge succeeds but the address_zip_check and address_line1_check verifications are both unavailable.
+        cvcFail: "4000000000000101"  # If a CVC number is provided, the cvc_check fails. If your account is blocking payments that fail CVC code validation, the charge is declined.
+        customerChargeFail: "4000000000000341"  # Attaching this card to a Customer object succeeds, but attempts to charge the customer fail.
+        successWithReview: "4000000000009235"  # Charge succeeds with a risk_level of elevated and placed into review.
+        declineCard: "4000000000000002"  # Charge is declined with a card_declined code.
+        declineFraudulentCard: "4100000000000019"  # Results in a charge with a risk level of highest. The charge is blocked as it's considered fraudulent.
+        declineIncorrectCvc: "4000000000000127"  # Charge is declined with an incorrect_cvc code.
+        declineExpired: "4000000000000069"  # Charge is declined with an expired_card code.
+        declineProcessingError: "4000000000000119"  # Charge is declined with a processing_error code.
+        declineIncorrectNumber: "4242424242424241"  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.
 # https://stripe.com/docs/testing

--- a/lib/locales/en/stripe.yml
+++ b/lib/locales/en/stripe.yml
@@ -29,35 +29,8 @@ en:
         declineExpired:         "4000000000000069"  # Charge is declined with an expired_card code.
         declineProcessingError: "4000000000000119"  # Charge is declined with a processing_error code.
         declineIncorrectNumber: "4242424242424241"  # Charge is declined with an incorrect_number code as the card number fails the Luhn check.
-      valid_card_objects:
-        - type:   "visa"
-          number: "#{valid_cards.visa}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(3)}"
-        - type:   "mastercard"
-          number: "#{valid_cards.mc}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(3)}"
-        - type:   "american express"
-          number: "#{valid_cards.amex}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(4)}"
-        - type:   "discover"
-          number: "#{valid_cards.discover}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(3)}"
-        - type:   "diners_club"
-          number: "#{valid_cards.diners_club}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(3)}"
-        - type:   "jcb"
-          number: "#{valid_cards.jcb}"
-          exp_mo: "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
-          exp_yr: "#{Time.new.year + Faker::Number.number(1)}"
-          ccv:    "#{Faker::Number.number(3)}"
+      valid_exp_mo:   "#{Time.new.month < 10 ? '%02d' % Time.new.month : Time.new.month}"
+      valid_exp_yr:   "#{'%02d' % (Time.new.year + 1)}"
+      valid_ccv:      Faker::Number.between(100,999)
+      valid_amex_ccv: Faker::Number.between(1000,9999)
 # https://stripe.com/docs/testing

--- a/test/test_faker_stripe.rb
+++ b/test/test_faker_stripe.rb
@@ -1,0 +1,35 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+class TestFakerStripe < Test::Unit::TestCase
+
+  def setup
+    @tester = Faker::Stripe
+  end
+
+  def test_valid_card
+    assert @tester.valid_card.match(/\d{15,16}$/)
+  end
+
+  def test_valid_card()
+    assert @tester.valid_card().match(/\d{15,16}$/)
+  end
+
+  def test_valid_token
+    assert @tester.valid_token.match(/^tok_/)
+    assert @tester.valid_token.match(/\w+/)
+  end
+
+  def test_valid_token()
+    assert @tester.valid_token.match(/^tok_/)
+    assert @tester.valid_token.match(/\w+/)
+  end
+
+  def test_card_error
+    assert @tester.card_error.match(/\d{16}$/)
+  end
+
+  def test_card_error_token
+    assert @tester.valid_token.match(/^tok_/)
+    assert @tester.error_token.match(/\w+/)
+  end
+end
+

--- a/test/test_faker_stripe.rb
+++ b/test/test_faker_stripe.rb
@@ -9,17 +9,17 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.valid_card.match(/\d{15,16}$/)
   end
 
-  def test_valid_card('visa')
-    assert @tester.valid_card().match(/\d{15,16}$/)
+  def test_specific_valid_card
+    assert @tester.valid_card("visa").match(/\d{15,16}$/)
   end
 
 
   def test_invalid_card
-    assert @tester.card_error.match(/\d{16}$/)
+    assert @tester.invalid_card.match(/\d{16}$/)
   end
 
-  def test_invalid_card('zipFail')
-    assert @tester.error_token.match(/\w+/)
+  def test_specific_error_invalid_card
+    assert @tester.invalid_card("zipFail").match(/\w+/)
   end
 end
 

--- a/test/test_faker_stripe.rb
+++ b/test/test_faker_stripe.rb
@@ -9,26 +9,16 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.valid_card.match(/\d{15,16}$/)
   end
 
-  def test_valid_card()
+  def test_valid_card('visa')
     assert @tester.valid_card().match(/\d{15,16}$/)
   end
 
-  def test_valid_token
-    assert @tester.valid_token.match(/^tok_/)
-    assert @tester.valid_token.match(/\w+/)
-  end
 
-  def test_valid_token()
-    assert @tester.valid_token.match(/^tok_/)
-    assert @tester.valid_token.match(/\w+/)
-  end
-
-  def test_card_error
+  def test_invalid_card
     assert @tester.card_error.match(/\d{16}$/)
   end
 
-  def test_card_error_token
-    assert @tester.valid_token.match(/^tok_/)
+  def test_invalid_card('zipFail')
     assert @tester.error_token.match(/\w+/)
   end
 end

--- a/test/test_faker_stripe.rb
+++ b/test/test_faker_stripe.rb
@@ -4,7 +4,6 @@ class TestFakerStripe < Test::Unit::TestCase
 
   def setup
     @tester = Faker::Stripe
-    @valid_card_object_list = I18n.translate('faker.stripe.valid_card_objects')
   end
 
   def test_valid_card
@@ -23,9 +22,20 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.invalid_card("zipFail").match(/\w+/)
   end
 
-  def test_valid_card_object
-    # assert @valid_card_object_list.any?{|hash| hash[:ccv] == @tester.valid_card_object[:ccv]}
-    assert @valid_card_object_list.include?(@tester.valid_card_object)
+  def test_valid_exp_mo
+    assert @tester.valid_month.match(/\d{2}/)
   end
+
+  def test_valid_exp_yr
+    assert @tester.valid_year.match(/\d{2}/)
+  end
+
+  def test_valid_ccv
+    assert @tester.valid_ccv.match(/\d{3}/)
+  end
+
+  def test_valid_amex_ccv
+    assert @tester.valid_amex_ccv.match(/\d{4}/)
+  end  
 end
 

--- a/test/test_faker_stripe.rb
+++ b/test/test_faker_stripe.rb
@@ -1,8 +1,10 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
+
 class TestFakerStripe < Test::Unit::TestCase
 
   def setup
     @tester = Faker::Stripe
+    @valid_card_object_list = I18n.translate('faker.stripe.valid_card_objects')
   end
 
   def test_valid_card
@@ -13,13 +15,17 @@ class TestFakerStripe < Test::Unit::TestCase
     assert @tester.valid_card("visa").match(/\d{15,16}$/)
   end
 
-
   def test_invalid_card
     assert @tester.invalid_card.match(/\d{16}$/)
   end
 
   def test_specific_error_invalid_card
     assert @tester.invalid_card("zipFail").match(/\w+/)
+  end
+
+  def test_valid_card_object
+    # assert @valid_card_object_list.any?{|hash| hash[:ccv] == @tester.valid_card_object[:ccv]}
+    assert @valid_card_object_list.include?(@tester.valid_card_object)
   end
 end
 


### PR DESCRIPTION
I added a class for Stripe credit card payment testing. I know there are two other classes that have credit cards in them (Business, Finance) but these card numbers do not trigger the requisite error codes and success codes back from Stripe that prove helpful in testing payments. Without something like this I have to hard code in all of the Stripe card numbers that trigger success and specific errors each time I test a stripe controller in an app. 

Maybe I am the only one that finds this annoying.

Also if anyone thinks I should move this all over to one of these two other classes and consolidate the credit card number generators I am happy to do so.