### PR TITLE
Add the @flexible_key value to the Vehicle Class

### DIFF
--- a/lib/faker/vehicle.rb
+++ b/lib/faker/vehicle.rb
@@ -1,5 +1,7 @@
 module Faker
   class Vehicle < Base
+    flexible :vehicle
+
     VIN_CHARS = '0123456789.ABCDEFGH..JKLMN.P.R..STUVWXYZ'
     VIN_MAP = '0123456789X'
     VIN_WEIGHTS = '8765432X098765432'

--- a/test/test_faker_vehicle.rb
+++ b/test/test_faker_vehicle.rb
@@ -20,6 +20,12 @@ class TestFakerVehicle < Test::Unit::TestCase
     assert @tester.manufacture.match(/\w+\.?/)
   end
 
+  def test_flexible_key
+    flexible_key = @tester.instance_variable_get("@flexible_key")
+
+    assert flexible_key == :vehicle
+  end
+
   private
 
     def transliterate(character)


### PR DESCRIPTION
In order to be able to use the `method_missing` feature