### PR TITLE
Add line to show min_length argument for user_name

### DIFF
--- a/doc/internet.md
+++ b/doc/internet.md
@@ -26,6 +26,9 @@ Faker::Internet.user_name('Nancy Johnson', %w(. _ -)) #=> "johnson-nancy"
 # Optional arguments: min_length=5, max_length=8
 Faker::Internet.user_name(5..8)
 
+# Optional argument min_length=8
+Faker::Internet.user_name(8)
+
 # Optional arguments: min_length=8, max_length=16
 Faker::Internet.password #=> "vg5msvy1uerg7"
 


### PR DESCRIPTION
It took me a while to understand that I could specify a minimum length. Even after looking at the source.
So we could add it to the docs! Cheers.