### PR TITLE
Use secure URL for lorempixel by default with optional opt-out.

### DIFF
--- a/lib/faker/lorem_pixel.rb
+++ b/lib/faker/lorem_pixel.rb
@@ -3,14 +3,15 @@ module Faker
     class << self
       SUPPORTED_CATEGORIES = %w(abstract animals business cats city food nightlife fashion people nature sports technics transport)
 
-      def image(size = '300x300', is_gray = false, category = nil, number = nil, text = nil)
+      def image(size = '300x300', is_gray = false, category = nil, number = nil, text = nil, secure = true)
         raise ArgumentError, 'Size should be specified in format 300x300' unless size.match(/^[0-9]+x[0-9]+$/)
         raise ArgumentError, "Supported categories are #{SUPPORTED_CATEGORIES.join(', ')}" unless category.nil? || SUPPORTED_CATEGORIES.include?(category)
         raise ArgumentError, 'Category required when number is passed' if !number.nil? && category.nil?
         raise ArgumentError, 'Number must be between 1 and 10' unless number.nil? || (1..10).include?(number)
         raise ArgumentError, 'Category and number must be passed when text is passed' if !text.nil? && number.nil? && category.nil?
 
-        url_parts = ['http://lorempixel.com']
+        url_parts = secure ? ['https:/'] : ['http:/']
+        url_parts << ['lorempixel.com']
         url_parts << 'g' if is_gray
         url_parts += size.split('x')
         url_parts += [category, number, text].compact

--- a/test/test_lorem_pixel.rb
+++ b/test/test_lorem_pixel.rb
@@ -5,12 +5,16 @@ class TestLoremPixel < Test::Unit::TestCase
     @tester = Faker::LoremPixel
   end
 
-  def test_placeholdit
-    assert @tester.image.match(/http:\/\/lorempixel\.com\/(\d+\/\d+)/)[1] != nil
+  def test_lorempixel
+    assert @tester.image.match(/https:\/\/lorempixel\.com\/(\d+\/\d+)/)[1] != nil
+  end
+
+  def test_lorempixel_insecure
+    assert @tester.image('300x300', nil, nil, nil, nil, false).match(/http:\/\/lorempixel\.com\/(\d+\/\d+)/)[1] != nil
   end
 
   def test_image_with_custom_size
-    assert @tester.image('3x3').match(/http:\/\/lorempixel\.com\/(\d+\/\d+)/)[1] == '3/3'
+    assert @tester.image('3x3').match(/https:\/\/lorempixel\.com\/(\d+\/\d+)/)[1] == '3/3'
   end
 
   def test_image_with_incorrect_size
@@ -20,11 +24,11 @@ class TestLoremPixel < Test::Unit::TestCase
   end
 
   def test_image_gray
-    assert @tester.image('300x300', true).match(/http:\/\/lorempixel\.com\/g\/\d+\/\d+/)
+    assert @tester.image('300x300', true).match(/https:\/\/lorempixel\.com\/g\/\d+\/\d+/)
   end
 
   def test_image_with_supported_category
-    assert @tester.image('300x300', false, 'animals').match(/http:\/\/lorempixel\.com\/\d+\/\d+\/(.*)/)[1] == 'animals'
+    assert @tester.image('300x300', false, 'animals').match(/https:\/\/lorempixel\.com\/\d+\/\d+\/(.*)/)[1] == 'animals'
   end
 
   def test_image_with_incorrect_category
@@ -34,7 +38,7 @@ class TestLoremPixel < Test::Unit::TestCase
   end
 
   def test_image_with_supported_category_and_correct_number
-    assert @tester.image('300x300', false, 'animals', 3).match(/http:\/\/lorempixel\.com\/\d+\/\d+\/.+\/(\d+)/)[1] == '3'
+    assert @tester.image('300x300', false, 'animals', 3).match(/https:\/\/lorempixel\.com\/\d+\/\d+\/.+\/(\d+)/)[1] == '3'
   end
 
   def test_image_with_supported_category_and_incorrect_number
@@ -50,11 +54,11 @@ class TestLoremPixel < Test::Unit::TestCase
   end
 
   def test_image_with_text_correct_number_and_supported_category
-    assert @tester.image('300x300', false, 'animals', 3, 'Dummy-text').match(/http:\/\/lorempixel\.com\/\d+\/\d+\/.+\/3\/(.+)/)[1] == 'Dummy-text'
+    assert @tester.image('300x300', false, 'animals', 3, 'Dummy-text').match(/https:\/\/lorempixel\.com\/\d+\/\d+\/.+\/3\/(.+)/)[1] == 'Dummy-text'
   end
 
   def test_image_with_text_supported_category_and_text_without_number
-    assert @tester.image('300x300', false, 'animals', nil, 'Dummy-text').match(/http:\/\/lorempixel\.com\/\d+\/\d+\/.+\/(.+)/)[1] == 'Dummy-text'
+    assert @tester.image('300x300', false, 'animals', nil, 'Dummy-text').match(/https:\/\/lorempixel\.com\/\d+\/\d+\/.+\/(.+)/)[1] == 'Dummy-text'
   end
 
   def test_image_with_text_without_number_and_category


### PR DESCRIPTION
This PR replaces `http://lorempixel.com` with `https://lorempixel.com` as the base of the image URL with the option to disable SSL by setting the sixth argument for the `image` method to false.