### PR TITLE
Remove broken example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,6 @@ that have been returned, for example between tests.
 Faker::Name.unique.clear # Clears used values for Faker::Name
 Faker::UniqueGenerator.clear # Clears used values for all generators
 ```
-It is also possible to add a random number to the end of faker data to increase the
-likelihood of unique data being generated. For example:
-
-```ruby
-Faker::Name.unique + ((1..1000).to_a).sample
-```
 
 ### Deterministic Random
 


### PR DESCRIPTION
Added in #836, but it doesn't work:

```ruby
[25] pry(main)> Faker::Name.unique + ((1..1000).to_a).sample
NoMethodError: undefined method `+' for Faker::Name:Class
from /Users/dentarg/.gem/ruby/2.4.2/gems/faker-1.8.4/lib/faker.rb:185:in `method_missing'
```