### PR TITLE
Fix: Return a collection for pluralized `::StarWars` class methods

### DIFF
--- a/lib/faker/star_wars.rb
+++ b/lib/faker/star_wars.rb
@@ -42,23 +42,23 @@ module Faker
       end
 
       def call_numbers
-        fetch('star_wars.call_numbers')
+        fetch_all('star_wars.call_numbers')
       end
 
       def call_squadrons
-        fetch('star_wars.call_squadrons')
+        fetch_all('star_wars.call_squadrons')
       end
 
       def characters
-        fetch('star_wars.characters')
+        fetch_all('star_wars.characters')
       end
 
       def droids
-        fetch('star_wars.droids')
+        fetch_all('star_wars.droids')
       end
 
       def planets
-        fetch('star_wars.planets')
+        fetch_all('star_wars.planets')
       end
 
       def quote(character = nil)
@@ -83,15 +83,15 @@ module Faker
       end
 
       def species
-        fetch('star_wars.species')
+        fetch_all('star_wars.species')
       end
 
       def vehicles
-        fetch('star_wars.vehicles')
+        fetch_all('star_wars.vehicles')
       end
 
       def wookiee_words
-        fetch('star_wars.wookiee_words')
+        fetch_all('star_wars.wookiee_words')
       end
 
       alias_method :wookie_sentence, :wookiee_sentence

--- a/test/test_faker_star_wars.rb
+++ b/test/test_faker_star_wars.rb
@@ -53,4 +53,36 @@ class TestFakerStarWars < Test::Unit::TestCase
   def test_wookiee_sentence
     assert @tester.wookiee_sentence.match(/\w+/)
   end
+
+  def test_call_numbers
+    assert @tester.call_numbers.is_a?(Array)
+  end
+
+  def test_call_squadrons
+    assert @tester.call_squadrons.is_a?(Array)
+  end
+
+  def test_characters
+    assert @tester.characters.is_a?(Array)
+  end
+
+  def test_droids
+    assert @tester.droids.is_a?(Array)
+  end
+
+  def test_planets
+    assert @tester.planets.is_a?(Array)
+  end
+
+  def test_species
+    assert @tester.species.is_a?(Array)
+  end
+
+  def test_vehicles
+    assert @tester.vehicles.is_a?(Array)
+  end
+
+  def test_wookiee_words
+    assert @tester.wookiee_words.is_a?(Array)
+  end
 end


### PR DESCRIPTION
## Changes

- Pluralized `::StarWars` methods were returning strings rather than arrays
- Fetch relevant data using `.fetch_all` rather than `.fetch`
  + `.call_numbers`
  + `.call_squadrons`
  + `.characters`
  + `.droids`
  + `.planets`
  + `.species`
  + `.vehicles`

### tl;dr

These pluralized methods were using `.fetch` which implements `.sample`, resulting in returning a single string. Using `.fetch_all` returns an array as expected.

---

fixes #1093