### PR TITLE
Fix I18n 0.9.3 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     ast (2.4.0)
     concurrent-ruby (1.0.5)
     docile (1.3.0)
-    i18n (0.9.1)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     launchy (2.4.3)

--- a/test/test_faker_city.rb
+++ b/test/test_faker_city.rb
@@ -9,8 +9,8 @@ class TestFakerCity < Test::Unit::TestCase
         address: { city_prefix: ['west'], city_suffix: ['burg'] }
       }
     }
-    I18n.backend.store_translations(:xx, xx)
     I18n.config.available_locales += [:xx]
+    I18n.backend.store_translations(:xx, xx)
 
     # rubocop:disable Lint/InterpolationCheck
     xy = {
@@ -25,8 +25,8 @@ class TestFakerCity < Test::Unit::TestCase
       }
     }
     # rubocop:enable Lint/InterpolationCheck
-    I18n.backend.store_translations(:xy, xy)
     I18n.config.available_locales += [:xy]
+    I18n.backend.store_translations(:xy, xy)
   end
 
   def teardown

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -40,8 +40,8 @@ class TestFakerCommerce < Test::Unit::TestCase
       }
     }
 
-    I18n.backend.store_translations(:xy, data)
     I18n.config.available_locales += [:xy]
+    I18n.backend.store_translations(:xy, data)
     I18n.with_locale(:xy) do
       assert_match ' + ', @tester.department(2, true)
     end

--- a/test/test_faker_street.rb
+++ b/test/test_faker_street.rb
@@ -22,8 +22,8 @@ class TestFakerStreet < Test::Unit::TestCase
       }
     }
     # rubocop:enable Lint/InterpolationCheck
-    I18n.backend.store_translations(:shire, shire)
     I18n.config.available_locales += [:shire]
+    I18n.backend.store_translations(:shire, shire)
   end
 
   def teardown

--- a/test/test_faker_zip_code.rb
+++ b/test/test_faker_zip_code.rb
@@ -26,9 +26,9 @@ class TestFakerZipCode < Test::Unit::TestCase
       }
     }
 
+    I18n.config.available_locales += %i[xy xz]
     I18n.backend.store_translations(:xy, locale_without_state)
     I18n.backend.store_translations(:xz, locale_with_state)
-    I18n.config.available_locales += %i[xy xz]
     @tester = Faker::Address
   end
 

--- a/test/test_flexible.rb
+++ b/test/test_flexible.rb
@@ -9,11 +9,11 @@ end
 class TestFlexible < Test::Unit::TestCase
   def setup
     @old_locales = I18n.config.available_locales
+    I18n.config.available_locales += %i[xx home kindergarden work]
     I18n.backend.store_translations(:xx, faker: { chow: { yummie: %i[fudge chocolate caramel], taste: 'delicious' } })
     I18n.backend.store_translations(:home, faker: { address: { birthplace: %i[bed hospital airplane] } })
     I18n.backend.store_translations(:kindergarden, faker: { name: { girls_name: %i[alice cheryl tatiana] } })
     I18n.backend.store_translations(:work, faker: { company: { do_stuff: %i[work work work] } })
-    I18n.config.available_locales += %i[xx home kindergarden work]
   end
 
   def teardown


### PR DESCRIPTION
Starting from version 0.9.3, I18n doesn't store translations for locales
not set as available.

This change set locales as available before storing translations.

Fix: #1132

Ref: svenfuchs/i18n#391