### PR TITLE
Update Faker::Omniauth to use Faker::Internet to create names and email addresses (+ bug-fix in Faker::Internet).

### DIFF
--- a/doc/omniauth.md
+++ b/doc/omniauth.md
@@ -9,7 +9,7 @@ Faker::Omniauth.google #=>
 #   :uid => "123456789",
 #   :info => {
 #     :name => "John Doe",
-#     :email => "john@company_name.com",
+#     :email => "john.doe@example.com",
 #     :first_name => "John",
 #     :last_name => "Doe",
 #     :image => "https://lh3.googleusercontent.com/url/photo.jpg"
@@ -23,7 +23,7 @@ Faker::Omniauth.google #=>
 #   :extra => {
 #     :raw_info => {
 #       :sub => "123456789",
-#       :email => "user@domain.example.com",
+#       :email => "john.doe@example.com",
 #       :email_verified => true,
 #       :name => "John Doe",
 #       :given_name => "John",
@@ -33,7 +33,7 @@ Faker::Omniauth.google #=>
 #       :gender => "male",
 #       :birthday => "0000-06-25",
 #       :locale => "en",
-#       :hd => "company_name.com"
+#       :hd => "example.com"
 #     },
 #     :id_info => {
 #       "iss" => "accounts.google.com",
@@ -55,7 +55,7 @@ Faker::Omniauth.facebook #=>
 #   provider: 'facebook',
 #   uid: '1234567',
 #   info: {
-#     email: 'joe@bloggs.com',
+#     email: 'joe_bloggs@example.com',
 #     name: 'Joe Bloggs',
 #     first_name: 'Joe',
 #     last_name: 'Bloggs',
@@ -77,7 +77,7 @@ Faker::Omniauth.facebook #=>
 #       username: 'jbloggs',
 #       location: { id: '123456789', name: 'Palo Alto, California' },
 #       gender: 'male',
-#       email: 'joe@bloggs.com',
+#       email: 'joe_bloggs@example.com',
 #       timezone: -8,
 #       locale: 'en_US',
 #       verified: true,
@@ -160,7 +160,7 @@ Faker::Omniauth.linkedin #=>
 #   "uid"=>"AbC123",
 #   "info"=> {
 #     "name"=>"John Doe",
-#     "email"=>"john@doe.com",
+#     "email"=>"doe.john@example.com",
 #     "nickname"=>"John Doe",
 #     "first_name"=>"John",
 #     "last_name"=>"Doe",
@@ -211,7 +211,7 @@ Faker::Omniauth.github #=>
 #   :uid =>"95144751",
 #   :info => {
 #     :nickname => "jackson-keeling",
-#     :email => "jackson@example.com",
+#     :email => "jackson.keeling@example.com",
 #     :name => "Jackson Keeling",
 #     :image => "https://placehold.it/300x300.png",
 #     :urls => {
@@ -245,7 +245,7 @@ Faker::Omniauth.github #=>
 #       :company => nil,
 #       :blog => nil,
 #       :location => "Paigeton, Massachusetts",
-#       :email => "jackson@example.com",
+#       :email => "jackson.keeling@example.com",
 #       :hireable => nil,
 #       :bio => nil,
 #       :public_repos => 263,

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -17,7 +17,7 @@ module Faker
       def user_name(specifier = nil, separators = %w(. _))
         with_locale(:en) do
           if specifier.respond_to?(:scan)
-            return specifier.scan(/\w+/).shuffle.join(sample(separators)).downcase
+            return shuffle(specifier.scan(/\w+/)).join(sample(separators)).downcase
           elsif specifier.kind_of?(Integer)
             # If specifier is Integer and has large value, Argument error exception is raised to overcome memory full error
             raise ArgumentError, "Given argument is too large" if specifier > 10**6

--- a/lib/faker/omniauth.rb
+++ b/lib/faker/omniauth.rb
@@ -3,12 +3,14 @@ module Faker
     require 'time'
     attr_reader :name,
                 :first_name,
-                :last_name
+                :last_name,
+                :email
 
     def initialize
       @name = "#{Name.first_name} #{Name.last_name}"
       @first_name = name.split(' ').first
       @last_name = name.split(' ').last
+      @email = Internet.safe_email(name)
     end
 
     class << self
@@ -23,7 +25,7 @@ module Faker
             name: auth.name,
             first_name: auth.first_name,
             last_name: auth.last_name,
-            email: email,
+            email: auth.email,
             image: image
           },
           credentials:  {
@@ -35,7 +37,7 @@ module Faker
           extra: {
             raw_info: {
               sub:  uid,
-              email: email,
+              email: auth.email,
               email_verified: random_boolean,
               name: auth.name,
               given_name: auth.first_name,
@@ -54,7 +56,7 @@ module Faker
             "email_verified" => "true",
             "sub" => Number.number(28).to_s,
             "azp" => "APP_ID",
-            "email" => email,
+            "email" => auth.email,
             "aud" => "APP_ID",
             "iat" => Number.number(10),
             "exp" => Time.forward.to_i.to_s,
@@ -72,7 +74,7 @@ module Faker
           provider: "facebook",
           uid: uid,
           info: {
-            email: email,
+            email: auth.email,
             name: auth.name,
             first_name: auth.first_name,
             last_name: auth.last_name,
@@ -97,7 +99,7 @@ module Faker
                 name: city_state
               },
               gender: gender,
-              email: email,
+              email: auth.email,
               timezone: timezone,
               locale: 'en_US',
               verified: random_boolean,
@@ -197,7 +199,7 @@ module Faker
           "uid" => uid,
           "info" => {
             "name" => auth.name,
-            "email" => email,
+            "email" => auth.email,
             "nickname" => auth.name,
             "first_name" => auth.first_name,
             "last_name" => auth.last_name,
@@ -260,7 +262,7 @@ module Faker
           uid: uid,
           info: {
             nickname: login,
-            email: email,
+            email: auth.email,
             name: auth.name,
             image: image,
             urls:{
@@ -294,7 +296,7 @@ module Faker
               company: nil,
               blog: nil,
               location: city_state,
-              email: email,
+              email: auth.email,
               hireable: nil,
               bio: nil,
               public_repos: random_number_from_range(1..1000),

--- a/lib/faker/omniauth.rb
+++ b/lib/faker/omniauth.rb
@@ -6,18 +6,15 @@ module Faker
                 :last_name,
                 :email
 
-    def initialize
-      @name = "#{Name.first_name} #{Name.last_name}"
-      @first_name = name.split(' ').first
-      @last_name = name.split(' ').last
-      @email = Internet.safe_email(name)
+    def initialize(name: nil, email: nil)
+      @name = name || "#{Name.first_name} #{Name.last_name}"
+      @email = email || Internet.safe_email(self.name)
+      @first_name, @last_name = self.name.split
     end
 
     class << self
-      def google
-        uid = Number.number(9)
-        auth = Omniauth.new()
-        email = "#{auth.first_name.downcase}@example.com"
+      def google(name: nil, email: nil, uid: Number.number(9))
+        auth = Omniauth.new(name: name, email: email)
         {
           provider: "google_oauth2",
           uid: uid,
@@ -65,11 +62,9 @@ module Faker
         }
       end
 
-      def facebook
-        uid = Number.number(7)
-        auth = Omniauth.new()
-        username = "#{auth.first_name.downcase[0]}#{auth.last_name.downcase}"
-        email = "#{auth.first_name.downcase}@#{auth.last_name.downcase}.com"
+      def facebook(name: nil, email: nil, username: nil, uid: Number.number(7))
+        auth = Omniauth.new(name: name, email: email)
+        username ||= "#{auth.first_name.downcase[0]}#{auth.last_name.downcase}"
         {
           provider: "facebook",
           uid: uid,
@@ -109,23 +104,23 @@ module Faker
         }
       end
 
-      def twitter
-        uid = Number.number(6)
-        auth = Omniauth.new()
+      def twitter(name: nil, nickname: nil, uid: Number.number(6))
+        auth = Omniauth.new(name: name)
+        nickname ||= auth.name.downcase.gsub(' ', '')
         location = city_state
         description = Lorem.sentence
         {
           provider: "twitter",
           uid: uid,
           info: {
-            nickname: auth.name.downcase.gsub(' ', ''),
+            nickname: nickname,
             name: auth.name,
             location: location,
             image: image,
             description: description,
             urls: {
               Website: nil,
-              Twitter: "https://twitter.com/#{auth.name.downcase.gsub(' ', '')}"
+              Twitter: "https://twitter.com/#{nickname}"
             }
           },
           credentials: {
@@ -182,12 +177,10 @@ module Faker
         }
       end
 
-      def linkedin
-        uid = Number.number(6)
-        auth = Omniauth.new()
+      def linkedin(name: nil, email: nil, uid: Number.number(6))
+        auth = Omniauth.new(name: name, email: email)
         first_name = auth.first_name.downcase
         last_name = auth.last_name.downcase
-        email = "#{first_name}@#{last_name}.com"
         location = city_state
         description = Lorem.sentence
         token = Crypto.md5
@@ -247,16 +240,11 @@ module Faker
         }
       end
 
-      def github
-        uid = Number.number(8)
-        auth = Omniauth.new()
-        first_name = auth.first_name.downcase
-        last_name  = auth.last_name.downcase
-        login = "#{first_name}-#{last_name}"
+      def github(name: nil, email: nil, uid: Number.number(8))
+        auth = Omniauth.new(name: name, email: email)
+        login = auth.name.downcase.gsub(' ','-')
         html_url = "https://github.com/#{login}"
         api_url = "https://api.github.com/users/#{login}"
-        email = "#{first_name}@example.com"
-
         {
           provider: "github",
           uid: uid,
@@ -308,7 +296,6 @@ module Faker
             }
           }
         }
-
       end
 
       private
@@ -336,7 +323,6 @@ module Faker
         def random_boolean
           shuffle([true, false]).pop
         end
-
     end
   end
 end

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -26,6 +26,12 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.user_name('bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
   end
 
+  def test_user_name_with_string_arg_determinism
+    deterministically_verify -> { @tester.user_name('bo peep') }, depth: 4 do |subject|
+      assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+    end
+  end
+
   def test_user_name_with_integer_arg
     (1..32).each do |min_length|
       assert @tester.user_name(min_length).length >= min_length

--- a/test/test_faker_omniauth.rb
+++ b/test/test_faker_omniauth.rb
@@ -14,13 +14,14 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     credentials     = auth[:credentials]
     extra_raw_info  = auth[:extra][:raw_info]
     id_info         = auth[:id_info]
+    safe_email_re   = /(#{info[:first_name]}(.|_)#{info[:last_name]}|#{info[:last_name]}(.|_)#{info[:first_name]})@example.(com|net|org)/i
     plus_url        = "https://plus.google.com/#{auth[:uid]}"
     openid_id       = "https://www.google.com/accounts/o8/id?id=#{auth[:uid]}"
 
     assert_equal "google_oauth2", provider
     assert_equal 9, uid.length
     assert_equal 2, word_count(info[:name])
-    assert_equal "#{info[:first_name].downcase}@example.com", info[:email]
+    assert info[:email].match(safe_email_re)
     assert_equal info[:name].split(' ').first, info[:first_name]
     assert_equal info[:name].split(' ').last, info[:last_name]
     assert_instance_of String, info[:image]
@@ -61,12 +62,12 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     extra_raw_info  = auth[:extra][:raw_info]
     username        = (info[:first_name][0] + info[:last_name]).downcase
     location        = extra_raw_info[:location]
-    email           = "#{info[:first_name].downcase}@#{info[:last_name].downcase}.com"
+    safe_email_re   = /(#{info[:first_name]}(.|_)#{info[:last_name]}|#{info[:last_name]}(.|_)#{info[:first_name]})@example.(com|net|org)/i
     url             = "http://www.facebook.com/#{username}"
 
     assert_equal "facebook", provider
     assert_equal 7, uid.length
-    assert_equal email, info[:email]
+    assert info[:email].match(safe_email_re)
     assert_equal 2, word_count(info[:name])
     assert_instance_of String, info[:first_name]
     assert_instance_of String, info[:last_name]
@@ -167,12 +168,12 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     first_name      = info['first_name'].downcase
     last_name       = info['last_name'].downcase
     url             = "http://www.linkedin.com/in/#{first_name}#{last_name}"
-    email           = "#{first_name}@#{last_name}.com"
+    safe_email_re   = /(#{first_name}(.|_)#{last_name}|#{last_name}(.|_)#{first_name})@example.(com|net|org)/
 
     assert_equal "linkedin", provider
     assert_equal 6, uid.length
     assert_equal 2, word_count(info["name"])
-    assert_equal email, info["email"]
+    assert info['email'].match(safe_email_re)
     assert_equal info["name"], info["nickname"]
     assert_instance_of String, info["first_name"]
     assert_instance_of String, info["last_name"]
@@ -213,7 +214,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     credentials     = auth[:credentials]
     name            = info[:name]
     login           = info[:nickname]
-    email           = "#{name.split(' ').first.downcase}@example.com"
+    safe_email_re   = /(#{info[:first_name]}(.|_)#{info[:last_name]}|#{info[:last_name]}(.|_)#{info[:first_name]})@example.(com|net|org)/i
     html_url        = "https://github.com/#{login}"
     api_url         = "https://api.github.com/users/#{login}"
     followers_url   = "#{api_url}/followers"
@@ -229,8 +230,8 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal "github", provider
     assert_equal 8, uid.length
     assert_equal uid, extra_raw_info[:id]
-    assert_equal email, info[:email]
-    assert_equal email, extra_raw_info[:email]
+    assert info[:email].match(safe_email_re)
+    assert_equal info[:email], extra_raw_info[:email]
     assert_equal 2, word_count(name)
     assert_instance_of String, name
     assert_equal name, extra_raw_info[:name]


### PR DESCRIPTION
`Faker::Internet.email` depends on `Faker::Internet.user_name`. In making this work, I uncovered a non-deterministic random bug in the `Faker::Internet.user_name` method, where `Array#shuffle` was used instead of `Faker::Base.shuffle` (see: [commit 79015b9](https://github.com/stympy/faker/commit/79015b9ca242e0dc65c249fda4c434c7f09f6740)).

The aforementioned bug slipped through existing tests, due to the variable arity of the `Faker::Internet.user_name` method.
