### PR TITLE
fix(currency-test): add whitespace in name regex

### DIFF
--- a/test/test_faker_currency.rb
+++ b/test/test_faker_currency.rb
@@ -6,7 +6,7 @@ class TestFakerCurrency < Test::Unit::TestCase
   end
 
   def test_name
-    assert @tester.name.match(/[\w\']+/)
+    assert @tester.name.match(/[\w\' ]+/)
   end
 
   def test_code


### PR DESCRIPTION
The currency "Kuwaiti Dinar" was not matched by previous regex.