### PR TITLE
First_name and last_name should use the parse method - :ru locale

### DIFF
--- a/lib/faker/name.rb
+++ b/lib/faker/name.rb
@@ -13,11 +13,11 @@ module Faker
       end
 
       def first_name
-        fetch('name.first_name')
+        parse('name.first_name')
       end
 
       def last_name
-        fetch('name.last_name')
+        parse('name.last_name')
       end
 
       def prefix

--- a/test/test_faker_name.rb
+++ b/test/test_faker_name.rb
@@ -14,6 +14,14 @@ class TestFakerName < Test::Unit::TestCase
     assert @tester.name_with_middle.match(/(\w+\.? ?){3,4}/)
   end
 
+  def test_first_name
+    assert @tester.first_name.match(/(\w+\.? ?){3,4}/)
+  end
+
+  def test_last_name
+    assert @tester.last_name.match(/(\w+\.? ?){3,4}/)
+  end
+
   def test_prefix
     assert @tester.prefix.match(/[A-Z][a-z]+\.?/)
   end


### PR DESCRIPTION
- [x] Fixed bug reported in the issue https://github.com/stympy/faker/issues/1154: we were basically using the wrong method, that's why it was printing the `"\#{female_last_name}"` or `"\#{male_last_name}"` outputs
- [x] Added two missing tests for `first_name` and `last_name` methods.

ps: I think this PR might be related to this one https://github.com/stympy/faker/issues/1024 as well