### PR TITLE
Fix tests warning

### DIFF
--- a/lib/faker/elder_scrolls.rb
+++ b/lib/faker/elder_scrolls.rb
@@ -29,10 +29,9 @@ module Faker
         fetch('elder_scrolls.first_name')
       end
 
-      def first_name
+      def last_name
         fetch('elder_scrolls.last_name')
       end
-
     end
   end
 end

--- a/test/test_faker_elder_scrolls.rb
+++ b/test/test_faker_elder_scrolls.rb
@@ -30,4 +30,11 @@ class TestFakerElderScrolls < Test::Unit::TestCase
     assert @tester.name.match(/\w+/)
   end
 
+  def test_first_name
+    assert @tester.first_name.match(/\w+/)
+  end
+
+  def test_last_name
+    assert @tester.last_name.match(/\w+/)
+  end
 end

--- a/test/test_faker_omniauth.rb
+++ b/test/test_faker_omniauth.rb
@@ -57,8 +57,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     auth                  = @tester.google(name: custom_name)
     info                  = auth[:info]
     extra_raw_info        = auth[:extra][:raw_info]
-    id_info               = auth[:id_info]
-
+    
     assert_instance_of String, info[:name]
     assert_equal 2, word_count(info[:name])
     assert_equal custom_name, info[:name]
@@ -184,7 +183,6 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
   def test_omniauth_facebook_with_uid
     custom_uid      = '12345'
     auth            = @tester.facebook(uid: custom_uid)
-    info            = auth[:info]
     extra_raw_info  = auth[:extra][:raw_info]
 
     assert_instance_of String, auth[:uid]
@@ -286,7 +284,6 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
   def test_omniauth_twitter_with_uid
     custom_uid  = '12345'
     auth        = @tester.twitter(uid: custom_uid)
-    info        = auth[:info]
     raw_info    = auth[:extra][:raw_info]
 
     assert_instance_of String, auth[:uid]
@@ -465,7 +462,6 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
   def test_omniauth_github_with_uid
     custom_uid      = '12345'
     auth            = @tester.github(uid: custom_uid)
-    info            = auth[:info]
     extra_raw_info  = auth[:extra][:raw_info]
 
     assert_instance_of String, auth[:uid]

--- a/test/test_zh_locale.rb
+++ b/test/test_zh_locale.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper.rb')
 
-class TestZhCnLocale < Test::Unit::TestCase
+class TestZhLocale < Test::Unit::TestCase
   def setup
     Faker::Config.locale = 'zh-CN'
   end


### PR DESCRIPTION
This PR was created because of this issue https://github.com/stympy/faker/issues/1171. 

The goal is to clean up the warnings that appear when we run `bundle && bundle exec rake`.

- [x] Removed unused test variables. 

![screen shot 2018-03-26 at 11 28 50 pm](https://user-images.githubusercontent.com/1292556/37943443-f329cde8-314d-11e8-8b9f-54831e149c05.png)

- [x] We had a duplicated test class which was resulting this warning:
```ruby
/Users/vitoroliveira/faker/test/test_zh_locale.rb:8: warning: method redefined; discarding old teardown
/Users/vitoroliveira/faker/test/test_zh_cn_locale.rb:8: warning: previous definition of teardown was here
```
- [x] ElderSchool had a duplicated method (two `first_name` methods). It should be `first_name` and `last_name`
- [x] Added tests for ElderSchool `first_name` and `last_name` methods