### PR TITLE
Add note that Number.between is inclusive in docs

### DIFF
--- a/doc/number.md
+++ b/doc/number.md
@@ -15,7 +15,8 @@ Faker::Number.normal(50, 3.5) #=> 47.14669604069156
 # Required parameter: digits
 Faker::Number.hexadecimal(3) #=> "e74"
 
-# Boundry numbers are inclusive
+# Required parameters: minimum value, maximum value
+# Boundary numbers are inclusive
 Faker::Number.between(1, 10) #=> 7
 
 Faker::Number.positive #=> 235.59238499107653

--- a/doc/number.md
+++ b/doc/number.md
@@ -15,6 +15,7 @@ Faker::Number.normal(50, 3.5) #=> 47.14669604069156
 # Required parameter: digits
 Faker::Number.hexadecimal(3) #=> "e74"
 
+# Boundry numbers are inclusive
 Faker::Number.between(1, 10) #=> 7
 
 Faker::Number.positive #=> 235.59238499107653


### PR DESCRIPTION
Just adding a simple note for future doc readers.

When I was looking up the documentation for Number.between I wasn't 100% sure if the boundary numbers were inclusive. Looking at the tests did show that it was.