### PR TITLE
Fix: Moved the Google Omniauth key id_info from root into extra

### DIFF
--- a/lib/faker/omniauth.rb
+++ b/lib/faker/omniauth.rb
@@ -35,7 +35,7 @@ module Faker
             raw_info: {
               sub:  uid,
               email: auth.email,
-              email_verified: random_boolean,
+              email_verified: random_boolean.to_s,
               name: auth.name,
               given_name: auth.first_name,
               family_name: auth.last_name,
@@ -49,13 +49,13 @@ module Faker
             id_info: {
               "iss" => "accounts.google.com",
               "at_hash" => Crypto.md5,
-              "email_verified" => "true",
+              "email_verified" => true,
               "sub" => Number.number(28).to_s,
               "azp" => "APP_ID",
               "email" => auth.email,
               "aud" => "APP_ID",
-              "iat" => Number.number(10),
-              "exp" => Time.forward.to_i.to_s,
+              "iat" => Time.forward.to_i,
+              "exp" => Time.forward.to_i,
               "openid_id" => "https://www.google.com/accounts/o8/id?id=#{uid}"
             }            
           }

--- a/lib/faker/omniauth.rb
+++ b/lib/faker/omniauth.rb
@@ -45,19 +45,19 @@ module Faker
               birthday: Date.backward(36_400).strftime('%Y-%m-%d'),
               local: 'en',
               hd: "#{Company.name.downcase}.com"
-            }
-          },
-          id_info: {
-            'iss' => 'accounts.google.com',
-            'at_hash' => Crypto.md5,
-            'email_verified' => 'true',
-            'sub' => Number.number(28).to_s,
-            'azp' => 'APP_ID',
-            'email' => auth.email,
-            'aud' => 'APP_ID',
-            'iat' => Number.number(10),
-            'exp' => Time.forward.to_i.to_s,
-            'openid_id' => "https://www.google.com/accounts/o8/id?id=#{uid}"
+            },
+            id_info: {
+              "iss" => "accounts.google.com",
+              "at_hash" => Crypto.md5,
+              "email_verified" => "true",
+              "sub" => Number.number(28).to_s,
+              "azp" => "APP_ID",
+              "email" => auth.email,
+              "aud" => "APP_ID",
+              "iat" => Number.number(10),
+              "exp" => Time.forward.to_i.to_s,
+              "openid_id" => "https://www.google.com/accounts/o8/id?id=#{uid}"
+            }            
           }
         }
       end

--- a/lib/faker/omniauth.rb
+++ b/lib/faker/omniauth.rb
@@ -47,17 +47,17 @@ module Faker
               hd: "#{Company.name.downcase}.com"
             },
             id_info: {
-              "iss" => "accounts.google.com",
-              "at_hash" => Crypto.md5,
-              "email_verified" => true,
-              "sub" => Number.number(28).to_s,
-              "azp" => "APP_ID",
-              "email" => auth.email,
-              "aud" => "APP_ID",
-              "iat" => Time.forward.to_i,
-              "exp" => Time.forward.to_i,
-              "openid_id" => "https://www.google.com/accounts/o8/id?id=#{uid}"
-            }            
+              'iss' => 'accounts.google.com',
+              'at_hash' => Crypto.md5,
+              'email_verified' => true,
+              'sub' => Number.number(28).to_s,
+              'azp' => 'APP_ID',
+              'email' => auth.email,
+              'aud' => 'APP_ID',
+              'iat' => Time.forward.to_i,
+              'exp' => Time.forward.to_i,
+              'openid_id' => "https://www.google.com/accounts/o8/id?id=#{uid}"
+            }
           }
         }
       end

--- a/test/test_faker_omniauth.rb
+++ b/test/test_faker_omniauth.rb
@@ -11,7 +11,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     info            = auth[:info]
     credentials     = auth[:credentials]
     extra_raw_info  = auth[:extra][:raw_info]
-    id_info         = auth[:id_info]
+    id_info         = auth[:extra][:id_info]
     plus_url        = "https://plus.google.com/#{auth[:uid]}"
     openid_id       = "https://www.google.com/accounts/o8/id?id=#{auth[:uid]}"
 
@@ -62,6 +62,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     auth                  = @tester.google(name: custom_name)
     info                  = auth[:info]
     extra_raw_info        = auth[:extra][:raw_info]
+    id_info               = auth[:extra][:id_info]
 
     assert_instance_of String, info[:name]
     assert_equal 2, word_count(info[:name])
@@ -79,7 +80,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     auth            = @tester.google(email: custom_email)
     info            = auth[:info]
     extra_raw_info  = auth[:extra][:raw_info]
-    id_info         = auth[:id_info]
+    id_info         = auth[:extra][:id_info]
 
     assert_instance_of String, info[:email]
     assert_equal custom_email, info[:email]

--- a/test/test_faker_omniauth.rb
+++ b/test/test_faker_omniauth.rb
@@ -34,7 +34,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal true, credentials[:expires]
     assert_equal 9, extra_raw_info[:sub].length
     assert_equal info[:email], extra_raw_info[:email]
-    assert [true, false].include? extra_raw_info[:email_verified]
+    assert ['true', 'false'].include? extra_raw_info[:email_verified]
     assert_equal info[:name], extra_raw_info[:name]
     assert_equal info[:first_name], extra_raw_info[:given_name]
     assert_equal info[:last_name], extra_raw_info[:family_name]
@@ -44,16 +44,16 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, extra_raw_info[:birthday]
     assert_equal 'en', extra_raw_info[:local]
     assert_instance_of String, extra_raw_info[:hd]
-    assert_equal 'accounts.google.com', id_info['iss']
-    assert_instance_of String, id_info['at_hash']
-    assert_instance_of String, id_info['email_verified']
-    assert_equal 28, id_info['sub'].length
-    assert_equal 'APP_ID', id_info['azp']
-    assert_equal info[:email], id_info['email']
-    assert_equal 'APP_ID', id_info['aud']
-    assert_instance_of String, id_info['iat']
-    assert_instance_of String, id_info['exp']
-    assert_equal openid_id, id_info['openid_id']
+    assert_equal "accounts.google.com", id_info["iss"]
+    assert_instance_of String, id_info["at_hash"]
+    assert [true, false].include? id_info["email_verified"]
+    assert_equal 28, id_info["sub"].length
+    assert_equal "APP_ID", id_info["azp"]
+    assert_equal info[:email], id_info["email"]
+    assert_equal "APP_ID", id_info["aud"]
+    assert_instance_of Fixnum, id_info["iat"]
+    assert_instance_of Fixnum, id_info["exp"]
+    assert_equal openid_id, id_info["openid_id"]
   end
 
   def test_omniauth_google_with_name

--- a/test/test_faker_omniauth.rb
+++ b/test/test_faker_omniauth.rb
@@ -34,7 +34,7 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_equal true, credentials[:expires]
     assert_equal 9, extra_raw_info[:sub].length
     assert_equal info[:email], extra_raw_info[:email]
-    assert ['true', 'false'].include? extra_raw_info[:email_verified]
+    assert %w[true false].include? extra_raw_info[:email_verified]
     assert_equal info[:name], extra_raw_info[:name]
     assert_equal info[:first_name], extra_raw_info[:given_name]
     assert_equal info[:last_name], extra_raw_info[:family_name]
@@ -44,16 +44,16 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     assert_instance_of String, extra_raw_info[:birthday]
     assert_equal 'en', extra_raw_info[:local]
     assert_instance_of String, extra_raw_info[:hd]
-    assert_equal "accounts.google.com", id_info["iss"]
-    assert_instance_of String, id_info["at_hash"]
-    assert [true, false].include? id_info["email_verified"]
-    assert_equal 28, id_info["sub"].length
-    assert_equal "APP_ID", id_info["azp"]
-    assert_equal info[:email], id_info["email"]
-    assert_equal "APP_ID", id_info["aud"]
-    assert_instance_of Fixnum, id_info["iat"]
-    assert_instance_of Fixnum, id_info["exp"]
-    assert_equal openid_id, id_info["openid_id"]
+    assert_equal 'accounts.google.com', id_info['iss']
+    assert_instance_of String, id_info['at_hash']
+    assert [true, false].include? id_info['email_verified']
+    assert_equal 28, id_info['sub'].length
+    assert_equal 'APP_ID', id_info['azp']
+    assert_equal info[:email], id_info['email']
+    assert_equal 'APP_ID', id_info['aud']
+    assert_instance_of Fixnum, id_info['iat']
+    assert_instance_of Fixnum, id_info['exp']
+    assert_equal openid_id, id_info['openid_id']
   end
 
   def test_omniauth_google_with_name
@@ -62,7 +62,6 @@ class TestFakerInternetOmniauth < Test::Unit::TestCase
     auth                  = @tester.google(name: custom_name)
     info                  = auth[:info]
     extra_raw_info        = auth[:extra][:raw_info]
-    id_info               = auth[:extra][:id_info]
 
     assert_instance_of String, info[:name]
     assert_equal 2, word_count(info[:name])


### PR DESCRIPTION
The Google Omniauth "id_info" hash should not be in the auth root, but under "extra", I moved it to where it rightfully belongs. 

Here are the details from the omniauth-google-oauth2 docs about the hash structure https://github.com/zquestz/omniauth-google-oauth2#auth-hash

Tests updated to account for this change.