### PR TITLE
Rename methods on Faker::Types to avoid shadowing ruby standard methods

### DIFF
--- a/doc/types.md
+++ b/doc/types.md
@@ -2,22 +2,22 @@
 
 ```ruby
 # Random String created from word (Faker::Lorem.word)
-Faker::Types.string #=> "foobar"
+Faker::Types.rb_string #=> "foobar"
 
 # Random Character a-z, 0-9
 Faker::Types.character #=> "n"
 
 # Random Integer
-Faker::Types.integer #=> 1
+Faker::Types.rb_integer #=> 1
 
 # Random Hash (with random keys and values)
-Faker::Types.hash #=> {name: "bob"}
+Faker::Types.rb_hash #=> {name: "bob"}
 
 # Random Complex Hash (values include other hashes and arrays) 
-Faker::Types.complex_hash #=> {user: {first: "bob", last: "marley"}}
+Faker::Types.complex_rb_hash #=> {user: {first: "bob", last: "marley"}}
 
 # Random Array
-Faker::Types.array #=> ["a", 1, 2, "bob"]
+Faker::Types.rb_array #=> ["a", 1, 2, "bob"]
 
 # Random Type (string, or integer)
 Faker::Types.random_type #=> 1 or "a" or "bob"

--- a/lib/faker/types.rb
+++ b/lib/faker/types.rb
@@ -5,7 +5,7 @@ module Faker
     COMPLEX_TYPES = %i[hash array].freeze
 
     class << self
-      def string(words = 1)
+      def rb_string(words = 1)
         resolved_num = resolve(words)
         word_list =
           translate('faker.lorem.words')
@@ -18,11 +18,11 @@ module Faker
         sample(CHARACTERS)
       end
 
-      def integer(from = 0, to = 100)
+      def rb_integer(from = 0, to = 100)
         rand(from..to).to_i
       end
 
-      def hash(key_count = 1)
+      def rb_hash(key_count = 1)
         {}.tap do |hsh|
           Lorem.words(key_count * 2).uniq.first(key_count).each do |s|
             hsh.merge!(s.to_sym => random_type)
@@ -30,7 +30,7 @@ module Faker
         end
       end
 
-      def complex_hash(key_count = 1)
+      def complex_rb_hash(key_count = 1)
         {}.tap do |hsh|
           Lorem.words(key_count * 2).uniq.first(key_count).each do |s|
             hsh.merge!(s.to_sym => random_complex_type)
@@ -38,7 +38,7 @@ module Faker
         end
       end
 
-      def array(len = 1)
+      def rb_array(len = 1)
         [].tap do |ar|
           len.times do
             ar.push random_type
@@ -50,11 +50,11 @@ module Faker
         type_to_use = SIMPLE_TYPES[rand(0..SIMPLE_TYPES.length - 1)]
         case type_to_use
         when :string
-          string
+          rb_string
         when :fixnum
-          integer
+          rb_integer
         else
-          integer
+          rb_integer
         end
       end
 
@@ -63,15 +63,15 @@ module Faker
         type_to_use = types[rand(0..types.length - 1)]
         case type_to_use
         when :string
-          string
+          rb_string
         when :fixnum
-          integer
+          rb_integer
         when :hash
-          hash
+          rb_hash
         when :array
-          array
+          rb_array
         else
-          integer
+          rb_integer
         end
       end
 

--- a/test/test_faker_types.rb
+++ b/test/test_faker_types.rb
@@ -8,14 +8,14 @@ class TestFakerTypes < Test::Unit::TestCase
     @tester = Faker::Types
   end
 
-  def test_string_is_or_correct_type
-    assert @tester.string.class == String
+  def test_rb_string_is_or_correct_type
+    assert @tester.rb_string.class == String
   end
 
   def test_string_returns_correct_number_of_words
-    assert @tester.string(1).split(' ').length == 1
-    assert @tester.string(5).split(' ').length == 5
-    assert @tester.string(0).split(' ').empty?
+    assert @tester.rb_string(1).split(' ').length == 1
+    assert @tester.rb_string(5).split(' ').length == 5
+    assert @tester.rb_string(0).split(' ').empty?
   end
 
   def test_character
@@ -24,47 +24,47 @@ class TestFakerTypes < Test::Unit::TestCase
 
   def test_integer
     if RUBY_VERSION < '2.4.0'
-      assert @tester.integer.class == Fixnum
+      assert @tester.rb_integer.class == Fixnum
     else
-      assert @tester.integer.class == Integer
+      assert @tester.rb_integer.class == Integer
     end
   end
 
-  def test_integer_between
+  def test_rb_integer_between
     from = Faker::Number.number.to_i
     to = from + Faker::Number.number.to_i
-    val = @tester.integer(from, to)
+    val = @tester.rb_integer(from, to)
     assert val < to && val >= from
   end
 
-  def test_hash_returns_a_hash
-    assert @tester.hash.class == Hash
+  def test_rb_hash_returns_a_hash
+    assert @tester.rb_hash.class == Hash
   end
 
   def test_hash_returns_the_correct_number_of_keys
-    assert @tester.hash(3).keys.length == 3
-    assert @tester.hash(0).keys.empty?
-    assert @tester.hash.keys.length == 1
+    assert @tester.rb_hash(3).keys.length == 3
+    assert @tester.rb_hash(0).keys.empty?
+    assert @tester.rb_hash.keys.length == 1
   end
 
-  def test_complex_hash_returns_a_hash
-    assert @tester.complex_hash.class == Hash
+  def test_complex_rb_hash_returns_a_hash
+    assert @tester.complex_rb_hash.class == Hash
   end
 
   def test_complex_hash_returns_the_correct_number_of_keys
-    assert @tester.complex_hash(3).keys.length == 3
-    assert @tester.complex_hash(0).keys.empty?
-    assert @tester.complex_hash.keys.length == 1
+    assert @tester.complex_rb_hash(3).keys.length == 3
+    assert @tester.complex_rb_hash(0).keys.empty?
+    assert @tester.complex_rb_hash.keys.length == 1
   end
 
-  def test_array_returns_array
-    assert @tester.array.class == Array
+  def test_rb_array_returns_array
+    assert @tester.rb_array.class == Array
   end
 
   def test_array_has_the_right_array
-    assert @tester.array(3).length == 3
-    assert @tester.array(0).empty?
-    assert @tester.array.length == 1
+    assert @tester.rb_array(3).length == 3
+    assert @tester.rb_array(0).empty?
+    assert @tester.rb_array.length == 1
   end
 
   def test_titleize


### PR DESCRIPTION
In particular, the class method `hash`, when shadowed, causes an error when `Faker::Types` is used as a hash key.

The issue is detailed in #1116.