### PR TITLE
Update sample output of `Faker::App.version`.

### DIFF
--- a/doc/app.md
+++ b/doc/app.md
@@ -3,7 +3,7 @@
 ```ruby
 Faker::App.name #=> "Treeflex"
 
-Faker::App.version #=> "0.7.9"
+Faker::App.version #=> "1.85"
 
 Faker::App.author #=> "Daphne Swift"
 


### PR DESCRIPTION
To better distinguish between `Faker::App.version` and `Faker::App.semantic_version`. The former can be semantic but not necessarily: 

```ruby
irb(main):001:0> Faker::App.version
=> "0.39"
irb(main):002:0> Faker::App.version
=> "8.3.9"
irb(main):003:0> Faker::App.version
=> "0.38"
irb(main):004:0> Faker::App.version
=> "2.2.3"
irb(main):005:0> Faker::App.version
=> "9.1.4"
irb(main):006:0> Faker::App.version
=> "4.17"
irb(main):007:0> Faker::App.version
=> "1.85"
irb(main):008:0> Faker::App.version
=> "9.72"
irb(main):009:0> Faker::App.version
=> "1.9"
irb(main):010:0> Faker::App.version
=> "0.42"
irb(main):011:0> Faker::App.version
=> "2.95"
irb(main):012:0> Faker::App.version
=> "0.7.8"
irb(main):013:0> Faker::App.version
=> "8.5"
```

This helps people grok the difference easier.