### PR TITLE
Show the type of field that violated a uniqueness constraint

### DIFF
--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -16,7 +16,7 @@ module Faker
         return result
       end
 
-      raise RetryLimitExceeded
+      raise RetryLimitExceeded, "Retry limit exceeded for #{name}"
     end
 
     RetryLimitExceeded = Class.new(StandardError)

--- a/test/test_faker_unique_generator.rb
+++ b/test/test_faker_unique_generator.rb
@@ -24,6 +24,21 @@ class TestFakerUniqueGenerator < Test::Unit::TestCase
     end
   end
 
+  def test_includes_field_name_in_error
+    stubbed_generator = Object.new
+    def stubbed_generator.my_field
+      1
+    end
+
+    generator = Faker::UniqueGenerator.new(stubbed_generator, 3)
+
+    generator.my_field
+
+    assert_raise_message "Retry limit exceeded for my_field" do
+      generator.my_field
+    end
+  end
+
   def test_clears_unique_values
     stubbed_generator = Object.new
     def stubbed_generator.test


### PR DESCRIPTION
When generating a factorybot item that has several fields with unique constraints, if it errors, there's no way to know what violated the constraint