### PR TITLE
Fix minitest warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 **Additions**
 
+- [PR #1223](https://github.com/stympy/faker/pull/1223) Fix minitest warnings [@vbrazo](https://github.com/vbrazo)
+- [PR #1174](https://github.com/stympy/faker/pull/1174) Dota2 API: Str Heroes, heroes quotes, Items, Teams, Players [@felipesousafs](https://github.com/darylf)
+- [PR #974](https://github.com/stympy/faker/pull/974) Specify version number each class was introduced [@darylf](https://github.com/darylf)
+- [PR #1221](https://github.com/stympy/faker/pull/1221) Updated the Readme file with the new logo [@tobaloidee](https://github.com/tobaloidee)
+- [PR #439](https://github.com/stympy/faker/pull/439) Remove Eichmann surname [@jonahwh](https://github.com/jonahwh)
+- [PR #1220](https://github.com/stympy/faker/pull/1220) Updates for Faker::Myst [@SpyMaster356](https://github.com/SpyMaster356)
+- [PR #1128](https://github.com/stympy/faker/pull/1128) Use ruby syntax highlighting in Omniauth doc [@swrobel](https://github.com/swrobel)
 - [PR #1204](https://github.com/stympy/faker/pull/1204) Update sample output of `Faker::App.version` [@joshuapinter](https://github.com/joshuapinter)
 - [PR #1218](https://github.com/stympy/faker/pull/1218) Add Faker::Myst [@SpyMaster356](https://github.com/SpyMaster356)
 - [PR #1192](https://github.com/stympy/faker/pull/1192) Space: Added space launch vehicule [@gauth-ier](https://github.com/Gauth-ier)

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,7 +4,6 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.libs << '.'
   t.test_files = FileList['test/test*.rb']
-  t.verbose = true
   t.warning = true
 end
 

--- a/test/test_faker_music.rb
+++ b/test/test_faker_music.rb
@@ -34,7 +34,7 @@ class TestFakerMusic < Test::Unit::TestCase
   end
 
   def test_key
-    assert @tester.name.match(/([A-Z])+(b|#){0,1}+(m){0,1}/)
+    assert @tester.name.match(/([A-Z])\s*(b|#){0,1}\s*(m){0,1}/)
   end
 
   def test_instrument
@@ -42,7 +42,7 @@ class TestFakerMusic < Test::Unit::TestCase
   end
 
   def test_chord
-    assert @tester.name.match(/([A-Z])+(b|#){0,1}+([a-zA-Z0-9]{0,4})/)
+    assert @tester.name.match(/([A-Z])\s*(b|#){0,1}\s*([a-zA-Z0-9]{0,4})/)
   end
 
   def test_band

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,8 @@ begin
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
+  simplecov_params = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(simplecov_params)
   SimpleCov.start do
     add_filter ['.bundle', 'lib/helpers', 'lib/extensions', 'test']
   end


### PR DESCRIPTION
Fix `minitest` warnings:

```/root/faker-ruby/faker/test/test_faker_music.rb:37: warning: nested repeat operator '?' and '*' was replaced with '*' in regular expression: /([A-Z])*(b|#){0,1}*(m){0,1}/```

```/root/faker-ruby/faker/test/test_faker_music.rb:45: warning: nested repeat operator '?' and '*' was replaced with '*' in regular expression: /([A-Z])*(b|#){0,1}*([a-zA-Z0-9]{0,4})/```

```/root/faker-ruby/faker/test/test_helper.rb:6:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.```

This PR is related to this issue https://github.com/stympy/faker/issues/1206.