### PR TITLE
Add image file method to placeholdit

### DIFF
--- a/doc/placeholdit.md
+++ b/doc/placeholdit.md
@@ -17,3 +17,18 @@ Faker::Placeholdit.image("50x50", 'jpeg', :random, :random) #=> "http://placehol
 
 Faker::Placeholdit.image("50x50", 'jpg', 'ffffff', '000', 'Some Custom Text') #=> "http://placehold.it/50x50.jpg/ffffff/000?text='Some Custom Text'"
 ```
+
+## Tips
+
+If you want to have this file downloaded, like in your tests, you could use this following piece of code:
+
+```ruby
+def image_file(size = '300x300', format = 'png', background_color = nil, text_color = nil, text = nil)
+  file = Tempfile.new("faker_placeholdit")
+  file.binmode
+  file << Net::HTTP.get(URI(Faker::Placeholdit.image(size, format, background_color, text_color, text)))
+  file.close
+
+  ::File.new(file.path)
+end
+```

--- a/doc/placeholdit.md
+++ b/doc/placeholdit.md
@@ -3,19 +3,19 @@
 ```ruby
 Faker::Placeholdit.image #=> "http://placehold.it/300x300.png/000"
 
-Faker::Placeholdit.image("50x50") #=> "http://placehold.it/50x50.png/000"
+Faker::Placeholdit.image('50x50') #=> "http://placehold.it/50x50.png/000"
 
-Faker::Placeholdit.image("50x50", 'jpg') #=> "http://placehold.it/50x50.jpg/000"
+Faker::Placeholdit.image('50x50', 'jpg') #=> "http://placehold.it/50x50.jpg/000"
 
-Faker::Placeholdit.image("50x50", 'gif', 'ffffff') #=> "http://placehold.it/50x50.gif/ffffff"
+Faker::Placeholdit.image('50x50', 'gif', 'ffffff') #=> "http://placehold.it/50x50.gif/ffffff"
 
-Faker::Placeholdit.image("50x50", 'jpeg', :random) #=> "http://placehold.it/50x50.jpeg/39eba7"
+Faker::Placeholdit.image('50x50', 'jpeg', :random) #=> "http://placehold.it/50x50.jpeg/39eba7"
 
-Faker::Placeholdit.image("50x50", 'jpeg', 'ffffff', '000') #=> "http://placehold.it/50x50.jpeg/ffffff/000"
+Faker::Placeholdit.image('50x50', 'jpeg', 'ffffff', '000') #=> "http://placehold.it/50x50.jpeg/ffffff/000"
 
-Faker::Placeholdit.image("50x50", 'jpeg', :random, :random) #=> "http://placehold.it/50x50.jpeg/d39e44/888ba7"
+Faker::Placeholdit.image('50x50', 'jpeg', :random, :random) #=> "http://placehold.it/50x50.jpeg/d39e44/888ba7"
 
-Faker::Placeholdit.image("50x50", 'jpg', 'ffffff', '000', 'Some Custom Text') #=> "http://placehold.it/50x50.jpg/ffffff/000?text='Some Custom Text'"
+Faker::Placeholdit.image('50x50', 'jpg', 'ffffff', '000', 'Some Custom Text') #=> "http://placehold.it/50x50.jpg/ffffff/000?text='Some Custom Text'"
 ```
 
 ## Tips

--- a/lib/faker/placeholdit.rb
+++ b/lib/faker/placeholdit.rb
@@ -11,8 +11,8 @@ module Faker
 
         raise ArgumentError, 'Size should be specified in format 300x300' unless size =~ /^[0-9]+x[0-9]+$/
         raise ArgumentError, "Supported formats are #{SUPPORTED_FORMATS.join(', ')}" unless SUPPORTED_FORMATS.include?(format)
-        raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || background_color.match(/((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/)
-        raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || text_color.match(/((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/)
+        raise ArgumentError, "background_color must be a hex value without '#'" unless background_color.nil? || background_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
+        raise ArgumentError, "text_color must be a hex value without '#'" unless text_color.nil? || text_color =~ /((?:^\h{3}$)|(?:^\h{6}$)){1}(?!.*\H)/
 
         image_url = "https://placehold.it/#{size}.#{format}"
         image_url += "/#{background_color}" if background_color


### PR DESCRIPTION
This PR add a `image_file` method in Placeholdit module to get a `File` object of the image, instead of just the URL.

Close #1217.