### PR TITLE
Update list of name prefixes for sv locale

### DIFF
--- a/lib/locales/sv.yml
+++ b/lib/locales/sv.yml
@@ -41,7 +41,7 @@ sv:
       first_name_men: [Erik, Lars, Karl, Anders, Per, Johan, Nils, Lennart, Emil, Hans, Jörgen, Göran, Håkan, Kåre]
       first_name: [Erik, Lars, Karl, Anders, Per, Johan, Nils, Lennart, Emil, Hans, Jörgen, Göran, Håkan, Kåre, Maria, Anna, Margareta, Elisabeth, Eva, Birgitta, Kristina, Karin, Elisabet, Marie, Åsa, Hjördis, Ingegärd]
       last_name: [Johansson, Andersson, Karlsson, Nilsson, Eriksson, Larsson, Olsson, Persson, Svensson, Gustafsson, Åslund, Östlund, Änglund]
-      prefix: [Dr., Prof., PhD.]
+      prefix: [civ.ek., civ.ing., ekon.dr, ekon. mag., ekon. kand., fil.dr, fil.lic., fil.kand., fil.mag., jur. kand., jur.utr.kand., jur.lic., jur.dr, med.dr, med.lic., med.kand., odont.kand., odont.lic., odont.dr, pol.kand., pol.mag., pol.dr, tekn.dr, tekn.lic., teol.kand., teol.lic., teol.dr]
 
       title:
         descriptor: [Lead, Senior, Direct, Corporate, Dynamic, Future, Product, National, Regional, District, Central, Global, Customer, Investor, Dynamic, International, Legacy, Forward, Internal, Human, Chief, Principal]

--- a/test/test_sv_locale.rb
+++ b/test/test_sv_locale.rb
@@ -15,6 +15,7 @@ class TestSVLocale < Test::Unit::TestCase
     assert Faker::Name.first_name_men.is_a? String
     assert Faker::Name.first_name_women.is_a? String
     assert Faker::Name.last_name.is_a? String
+    assert Faker::Name.prefix.is_a? String
   end
 
   def test_sv_phone_number


### PR DESCRIPTION
This PR changes list of available name prefixes (`Faker::Name.prefix`) for SV locale, as requested in https://github.com/stympy/faker/issues/1231