### PR TITLE
Fixing documentation - Faker::Name to Faker::Zelda

### DIFF
--- a/doc/name.md
+++ b/doc/name.md
@@ -17,4 +17,6 @@ Faker::Name.title            #=> "Legacy Creative Director"
 
 Faker::Name.initials         #=> "NJM"
 Faker::Name.initials(2)      #=> "NM"
+
+Faker::Name.job_titles       #=> [""Supervisor", "Associate", ...]
 ```

--- a/doc/nation.md
+++ b/doc/nation.md
@@ -9,4 +9,3 @@ Faker::Nation.language #=> "Nepali"
 
 # Random Capital City
 Faker::Nation.capital_city #=> "Kathmandu"
-Faker::Nation.capital_city #=> "New Delhi"

--- a/doc/nato_phonetic_alphabet.md
+++ b/doc/nato_phonetic_alphabet.md
@@ -1,6 +1,6 @@
-# Faker::Hobbit
+# Faker::NatoPhoneticAlphabet
 
 ```ruby
 # A code word from the NATO phonetic alphabet
-Faker::NatoPhoneticAlphabet #=> "Hotel"
+Faker::NatoPhoneticAlphabet.code_word #=> "Hotel"
 ```

--- a/doc/number.md
+++ b/doc/number.md
@@ -4,6 +4,12 @@
 # Required parameter: digits
 Faker::Number.number(10) #=> "1968353479"
 
+# Required parameter: digits
+Faker::Number.leading_zero_number(10) #=> "0669336915"
+
+# Required parameter: digits
+Faker::Number.decimal_part(2) #=> "0074009009"
+
 # Required parameter: l_digits
 Faker::Number.decimal(2) #=> "11.88"
 
@@ -22,6 +28,8 @@ Faker::Number.between(1, 10) #=> 7
 Faker::Number.positive #=> 235.59238499107653
 
 Faker::Number.negative #=> -4480.042585669558
+
+Faker::Number.non_zero_digit #=> "8"
 
 Faker::Number.digit #=> "1"
 ```

--- a/doc/star_wars.md
+++ b/doc/star_wars.md
@@ -3,7 +3,11 @@
 Available since version 1.6.2.
 
 ```ruby
+Faker::StarWars.call_squadron #=> "Green"
+
 Faker::StarWars.call_sign #=> "Grey 5"
+
+Faker::StarWars.call_number #=> "Leader"
 
 Faker::StarWars.character #=> "Anakin Skywalker"
 

--- a/doc/university.md
+++ b/doc/university.md
@@ -5,6 +5,16 @@ Available since version 1.5.0.
 ```ruby
 # Random University Name
 Faker::University.name #=> "South Texas College"
+
+# Random University Prefix
+Faker::University.prefix #=> "North"
+
+# Random University Suffix
+Faker::University.suffix #=> "Institute"
+
 # Random Greek Organization
 Faker::University.greek_organization #=> "ABΓ"
+
+# Greek Alphabet
+Faker::University.greek_alphabet #=> ["Α", "B", "Γ", "Δ", ...]
 ```

--- a/lib/faker/team.rb
+++ b/lib/faker/team.rb
@@ -15,6 +15,10 @@ module Faker
         fetch('address.state')
       end
 
+      def sport
+        fetch('team.sport')
+      end
+
       def mascot
         fetch('team.mascot')
       end


### PR DESCRIPTION
An extension of #1252.

Here are the issues that I have found relating to the documentation.

- [x] `Faker::Name.job_titles` - not in docs
- [x] `Faker::Nation.capital_city` - duplicated in docs
- [x] `Faker::NatoPhoneticAlphabet` - incorrect title in doc
- [x] `Faker::NatoPhoneticAlphabet.code_word` - missing method name in doc
- [x] `Faker::Number.leading_zero_number` - not in docs
- [x] `Faker::Number.decimal_part` - not in docs
- [x] `Faker::Number.non_zero_digit` - not in docs
- [x] `Faker::StarWars.call_squadron` - not in docs
- [x] `Faker::StarWars.call_number` - not in docs
- [x] `Faker::Team.sport` - no code
- [x] `Faker::University.prefix` - not in docs (should be protected?)
- [x] `Faker::University.suffix` - not in docs (should be protected?)
- [x] `Faker::University.greek_alphabet` - not in docs (should be private?)