### PR TITLE
Fix method name in Faker::SingularSiegler

### DIFF
--- a/lib/faker/singular_siegler.rb
+++ b/lib/faker/singular_siegler.rb
@@ -1,7 +1,7 @@
 module Faker
   class SingularSiegler < Base
     class << self
-      def quotes
+      def quote
         fetch('singular_siegler.quotes')
       end
     end


### PR DESCRIPTION
Renamed `quotes` to `quote` to match documentation.