### PR TITLE
Remove simplecov-console and add coverage_report rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 ### Latest update: 2018-05-22
 
 ### Feature Request
-- [PR #1247](https://github.com/stympy/faker/pull/1247) Generate capital city of random Nation [gkunwar](https://github.com/gkunwar)
-- [PR #1250](https://github.com/stympy/faker/pull/1250) House appliances [rafaelcpalmeida](https://github.com/rafaelcpalmeida)
-- [PR #1239](https://github.com/stympy/faker/pull/1239) Update Faker::Food to separate out Fruits and Veggies [susiirwin](https://github.com/susiirwin)
+- [PR #1258](https://github.com/stympy/faker/pull/1258) Remove simplecov-console and add coverage_report rake task [@vbrazo](https://github.com/vbrazo)
+- [PR #1247](https://github.com/stympy/faker/pull/1247) Generate capital city of random Nation [@gkunwar](https://github.com/gkunwar)
+- [PR #1250](https://github.com/stympy/faker/pull/1250) House appliances [@rafaelcpalmeida](https://github.com/rafaelcpalmeida)
+- [PR #1239](https://github.com/stympy/faker/pull/1239) Update Faker::Food to separate out Fruits and Veggies [@susiirwin](https://github.com/susiirwin)
 - [PR #1221](https://github.com/stympy/faker/pull/1221) Updated the Readme file with the new logo [@tobaloidee](https://github.com/tobaloidee)
 - [PR #1109](https://github.com/stympy/faker/pull/1109) Added Princess Bride [@jayphodges](https://github.com/jayphodges)
 - [PR #987](https://github.com/stympy/faker/pull/987) Add Faker::Cannabis class [@GhostGroup](https://github.com/GhostGroup)
@@ -72,6 +73,8 @@
 - [PR #1173](https://github.com/stympy/faker/pull/1173) Fix tests warning [@vbrazo](https://github.com/vbrazo)
 
 ### Documentation
+- [PR #1257](https://github.com/stympy/faker/pull/1257) Fix method name in Faker::SingularSiegler [mrstebo](https://github.com/mrstebo)
+- [PR #1256](https://github.com/stympy/faker/pull/1256) Fixing documentation - Faker::Name to Faker::Zelda [mrstebo](https://github.com/mrstebo)
 - [PR #1254](https://github.com/stympy/faker/pull/1254) Added missing documentation. [mrstebo](https://github.com/mrstebo)
 - [PR #1252](https://github.com/stympy/faker/pull/1252) Add missing documentation - Faker::Address to Faker::Myst [vbrazo](https://github.com/vbrazo)
 - [PR #1248](https://github.com/stympy/faker/pull/1248) Remove duplications from company.md [vrinek](https://github.com/vrinek)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,20 +23,24 @@ the Base class (just like the rest of the code) rather than
 `Array#sample`, `Array#shuffle` and `Kernel#rand` to preserve the
 deterministic feature.
 
-6. When adding a new class, add a new yaml file to
+6. We care about code coverage and use `SimpleCov` to analyze the code and generate
+test coverage reports. It's possible to check the test coverage by running 
+`bundle exec rake coverage_report`. Please make sure to not decrease our `current % covered`.
+
+7. When adding a new class, add a new yaml file to
 `lib/locales/en` rather than adding translations to
 `lib/locales/en.yml`.  For example, if you add Faker::MyThing,
 put your translations in `lib/locales/en/my_thing.yml`.  See [the locale
 README](./lib/locales/en/README.md) for more info.
 
-7. Methods with optional arguments should use keyword rather than positional 
+8. Methods with optional arguments should use keyword rather than positional 
 arguments. An exception to this could be a method that takes only one 
 optional argument, and it's unlikely that that method would ever take more
 than one optional argument.
 
-8. Push to your fork and submit a pull request.
+9. Push to your fork and submit a pull request.
 
-### Github Flow
+### Github Flow for collaborator and contributors
 
 For those of you with commit access, please check out Scott Chacon's blog post about [github flow](http://scottchacon.com/2011/08/31/github-flow.html)
 
@@ -46,7 +50,15 @@ For those of you with commit access, please check out Scott Chacon's blog post a
 > * When you need feedback or help, or you think the branch is ready for merging, open a pull request
 > * After someone else has reviewed and signed off on the feature, you can merge it into master
 
-Syntax/Good practices:
+If you're reviewing a PR, you should ask youserlf:
+- Does it work as described? A PR should have a great description.
+- Is it understandable?
+- Is it well implemented?
+- Is it well tested?
+- Is it well documented?
+- Is it following the structure of the project?
+
+### Syntax/Good practices:
 
 * Two spaces, no tabs.
 * No trailing whitespace. Blank lines should not have any space.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,20 +7,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ansi (1.5.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     concurrent-ruby (1.0.5)
     docile (1.3.0)
-    hirb (0.7.3)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     minitest (5.10.3)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     power_assert (1.1.1)
     powerpack (0.1.1)
+    public_suffix (3.0.2)
     rainbow (3.0.0)
     rake (12.3.0)
     rubocop (0.56.0)
@@ -35,10 +38,6 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-console (0.4.2)
-      ansi
-      hirb
-      simplecov
     simplecov-html (0.10.2)
     test-unit (3.2.6)
       power_assert
@@ -50,11 +49,11 @@ PLATFORMS
 
 DEPENDENCIES
   faker!
+  launchy
   minitest
   rake
   rubocop
   simplecov
-  simplecov-console
   test-unit
   timecop
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ task :console do
 end
 
 task :coverage_report do
-  require 'rubygems'
   require 'launchy'
 
   Launchy.open('coverage/index.html')

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,16 @@ task :console do
   require 'irb'
   require 'irb/completion'
   require 'faker' # You know what to do.
+
   ARGV.clear
   IRB.start
+end
+
+task :coverage_report do
+  require 'rubygems'
+  require 'launchy'
+
+  Launchy.open('coverage/index.html')
 end
 
 require 'rubocop/rake_task'

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_runtime_dependency('i18n', '>= 0.7')
+  s.add_development_dependency('launchy')
   s.add_development_dependency('minitest')
   s.add_development_dependency('rake')
   s.add_development_dependency('rubocop')
   s.add_development_dependency('simplecov')
-  s.add_development_dependency('simplecov-console')
   s.add_development_dependency('test-unit')
   s.add_development_dependency('timecop')
   s.required_ruby_version = '>= 2.1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,5 @@
 require 'simplecov'
-require 'simplecov-console'
-SimpleCov.formatter = SimpleCov.formatter = SimpleCov::Formatter::Console
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.start do
   add_filter ['.bundle', 'test']
 end


### PR DESCRIPTION
- Remove `simplecov-console` because it shows a few warnings in the console
- Add `launchy` gem to help us open html pages in a browser
- Add rake task to open the `html report` generated by SimpleCov after running the tests

You should simply run: `bundle exec rake coverage_report` to see the coverage report.