### PR TITLE
Ensure translation exists

### DIFF
--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -176,7 +176,8 @@ module Faker
         super unless @flexible_key
 
         # Use the alternate form of translate to get a nil rather than a "missing translation" string
-        if (translation = translate(:faker)[@flexible_key][mth])
+        translation = translate(:faker)[@flexible_key] && translate(:faker)[@flexible_key][mth]
+        if translation
           sample(translation)
         else
           super


### PR DESCRIPTION
We're using `faker` version 1.8.7, and when we set `I18n.locale = :fr` and run `Faker::Job.position`, the code fails with this error:

```
NoMethodError: undefined method `[]' for nil:NilClass
/Users/my_user/.gem/ruby/2.5.1/gems/faker-1.8.7/lib/faker.rb:182:in `method_missing'
```

We're using Ruby 2.5.1.

I found out that the French locale does not have the `job` key, so this line fails:

https://github.com/stympy/faker/blob/bc912ae08ec8c369ca2cee543656f70207d2a84a/lib/faker.rb#L182

`translate(:faker)[@flexible_key]` returns `nil`, so here's the problem. I'm ensuring `translate(:faker)[@flexible_key]` is present, and then check `translate(:faker)[@flexible_key][m]` to retrieve the value.

I would have used `dig` (`translate(:faker).dig(@flexible_key, m)`), but it was added on Ruby 2.3 and this project seems to support Ruby 2.1+, so that's the only way to do it AFAIK.

I'm not sure how to test this, can someone help me?

Thanks! 😄 