### PR TITLE
Fix flexible keys crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - [PR #1117](https://github.com/stympy/faker/pull/1117) Added Ukrainian entries to yml [@RomanIsko](https://github.com/RomanIsko)
 
 ### Bug/Fixes
+- [PR #1292](https://github.com/stympy/faker/pull/1292) Fix flexible keys crashing when current locale does not provide them [@deivid-rodriguez](https://github.com/deivid-rodriguez)
 - [PR #1274](https://github.com/stympy/faker/pull/1274) Allow Faker::Address.zip_code to have leading zero [@igor-starostenko](https://github.com/igor-starostenko)
 - [PR #1241](https://github.com/stympy/faker/pull/1241) Add missing tests reported by SimpleCov [@aamarill](https://github.com/aamarill)
 - [PR #1240](https://github.com/stympy/faker/pull/1240) Add some tests [@aamarill](https://github.com/aamarill)

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -176,8 +176,7 @@ module Faker
       def method_missing(mth, *args, &block)
         super unless @flexible_key
 
-        # Use the alternate form of translate to get a nil rather than a "missing translation" string
-        if (translation = translate(:faker)[@flexible_key][mth])
+        if (translation = translate("faker.#{@flexible_key}.#{mth}"))
           sample(translation)
         else
           super

--- a/test/test_flexible.rb
+++ b/test/test_flexible.rb
@@ -22,8 +22,7 @@ class TestFlexible < Test::Unit::TestCase
 
   def test_flexible_multiple_values
     I18n.with_locale(:xx) do
-      actual = Faker::Foodie.yummie
-      assert %i[fudge chocolate caramel].include? actual
+      assert %i[fudge chocolate caramel].include? Faker::Foodie.yummie
     end
   end
 

--- a/test/test_flexible.rb
+++ b/test/test_flexible.rb
@@ -32,9 +32,19 @@ class TestFlexible < Test::Unit::TestCase
     end
   end
 
-  def test_raises_no_method_error
+  def test_flexible_fallbacks_to_english
+    I18n.backend.store_translations(:en, faker: { chow: { taste: 'superdelicious' } })
+
+    I18n.with_locale(:home) do
+      assert_equal 'superdelicious', Faker::Foodie.taste
+    end
+
+    I18n.reload!
+  end
+
+  def test_raises_missing_translation_data_when_not_even_english_defined
     I18n.with_locale(:xx) do
-      assert_raise(NoMethodError) do
+      assert_raise(I18n::MissingTranslationData) do
         Faker::Foodie.eeew
       end
     end


### PR DESCRIPTION
Just like with regular keys, flexible keys should default to English when they are not present. Fixes #1286.

There's an unrelated change that simplifies how `test_helper` is required. Without this, `ruby test/test_flexible.rb` was failing on my environment. Let me know if you want that as a separate PR.