### PR TITLE
Add Faker::Alphanumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Contents
 - [Installing](#installing)
 - [Usage](#usage)
   - [Faker::Address](doc/address.md)
+  - [Faker::Alphanum](doc/alphanum.md)
   - [Faker::Ancient](doc/ancient.md)
   - [Faker::App](doc/app.md)
   - [Faker::Appliance](doc/appliance.md)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Contents
 - [Installing](#installing)
 - [Usage](#usage)
   - [Faker::Address](doc/address.md)
-  - [Faker::Alphanum](doc/alphanum.md)
+  - [Faker::Alphanumeric](doc/alphanumeric.md)
   - [Faker::Ancient](doc/ancient.md)
   - [Faker::App](doc/app.md)
   - [Faker::Appliance](doc/appliance.md)

--- a/doc/alphanum.md
+++ b/doc/alphanum.md
@@ -1,0 +1,9 @@
+# Faker::Alphanum
+
+It might be available in the next version.
+
+```ruby
+Faker::Alphanumeric.alpha 10 #=> "zlvubkrwga"
+
+Faker::Alphanumeric.alphanumeric 10 #=> "3yfq2phxtb"
+```

--- a/doc/alphanumeric.md
+++ b/doc/alphanumeric.md
@@ -1,4 +1,4 @@
-# Faker::Alphanum
+# Faker::Alphanumeric
 
 It might be available in the next version.
 

--- a/lib/faker.rb
+++ b/lib/faker.rb
@@ -201,6 +201,16 @@ module Faker
         rand(from..to)
       end
 
+      # If an array or range is passed, a random value will be selected.
+      # All other values are simply returned.
+      def resolve(value)
+        case value
+        when Array then sample(value)
+        when Range then rand value
+        else value
+        end
+      end
+
       def unique(max_retries = 10_000)
         @unique ||= UniqueGenerator.new(self, max_retries)
       end

--- a/lib/faker/alphanumeric.rb
+++ b/lib/faker/alphanumeric.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Faker
+  class Alphanumeric < Base
+    class << self
+      ALPHABET = ('a'..'z').to_a
+      ALPHANUMS = ALPHABET + (0..9).to_a
+
+      def alpha(char_count = 32)
+        char_count = resolve(char_count)
+        return '' if char_count.to_i < 1
+        Array.new(char_count) { sample(ALPHABET) }.join
+      end
+
+      def alphanumeric(char_count = 32)
+        char_count = resolve(char_count)
+        return '' if char_count.to_i < 1
+        Array.new(char_count) { sample(ALPHANUMS) }.join
+      end
+
+      private
+
+      # If an array or range is passed, a random value will be selected.
+      # All other values are simply returned.
+      def resolve(value)
+        case value
+        when Array then sample(value)
+        when Range then rand value
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/faker/alphanumeric.rb
+++ b/lib/faker/alphanumeric.rb
@@ -17,18 +17,6 @@ module Faker
         return '' if char_count.to_i < 1
         Array.new(char_count) { sample(ALPHANUMS) }.join
       end
-
-      private
-
-      # If an array or range is passed, a random value will be selected.
-      # All other values are simply returned.
-      def resolve(value)
-        case value
-        when Array then sample(value)
-        when Range then rand value
-        else value
-        end
-      end
     end
   end
 end

--- a/lib/faker/hipster.rb
+++ b/lib/faker/hipster.rb
@@ -52,18 +52,6 @@ module Faker
 
         paragraph[0...chars - 1] + '.'
       end
-
-      private
-
-      # If an array or range is passed, a random value will be selected.
-      # All other values are simply returned.
-      def resolve(value)
-        case value
-        when Array then value[rand(value.size)]
-        when Range then value.to_a[rand(value.size)]
-        else value
-        end
-      end
     end
   end
 end

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -3,8 +3,6 @@
 module Faker
   # Based on Perl's Text::Lorem
   class Lorem < Base
-    CHARACTERS = ('0'..'9').to_a + ('a'..'z').to_a
-
     class << self
       def word
         sample(translate('faker.lorem.words'))
@@ -21,7 +19,7 @@ module Faker
       end
 
       def character
-        sample(CHARACTERS)
+        sample(Types::CHARACTERS)
       end
 
       def characters(char_count = 255)

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -25,9 +25,7 @@ module Faker
       end
 
       def characters(char_count = 255)
-        char_count = resolve(char_count)
-        return '' if char_count.to_i < 1
-        Array.new(char_count) { sample(CHARACTERS) }.join
+        Alphanumeric.alphanumeric(char_count)
       end
 
       def multibyte

--- a/lib/faker/lorem.rb
+++ b/lib/faker/lorem.rb
@@ -77,16 +77,6 @@ module Faker
       def locale_question_mark
         translate('faker.lorem.punctuation.question_mark') || '?'
       end
-
-      # If an array or range is passed, a random value will be selected.
-      # All other values are simply returned.
-      def resolve(value)
-        case value
-        when Array then sample(value)
-        when Range then rand value
-        else value
-        end
-      end
     end
   end
 end

--- a/lib/faker/lovecraft.rb
+++ b/lib/faker/lovecraft.rb
@@ -65,18 +65,6 @@ module Faker
 
         paragraph[0...chars - 1] + '.'
       end
-
-      private
-
-      # If an array or range is passed, a random value will be selected.
-      # All other values are simply returned.
-      def resolve(value)
-        case value
-        when Array then sample(value)
-        when Range then rand value
-        else value
-        end
-      end
     end
   end
 end

--- a/lib/faker/types.rb
+++ b/lib/faker/types.rb
@@ -74,14 +74,6 @@ module Faker
       def titleize(word)
         word.split(/(\W)/).map(&:capitalize).join
       end
-
-      def resolve(value)
-        case value
-        when Array then sample(value)
-        when Range then rand value
-        else value
-        end
-      end
     end
   end
 end

--- a/test/test_alphanum.rb
+++ b/test/test_alphanum.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class TestFakerAlphanum < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Alphanumeric
+  end
+
+  def alpha
+    assert @tester.alpha(5).match(/[a-z]{5}/)
+  end
+
+  def alphanum
+    assert @tester.alphanumeric(5).match(/[a-z0-9]{5}/)
+  end
+end


### PR DESCRIPTION
Simple alphanumeric generator for random alphanumeric strings. I think it's useful to have the ability to create simple (unique) strings. 

From the documentation:
```ruby
Faker::Alphanumeric.alpha 10 #=> "zlvubkrwga"
Faker::Alphanumeric.alphanum 10 #=> "3yfq2phxtb"
```

- [x] Class
- [x] New tests
- [x] New doc
- [x] Rubocoped