### PR TITLE
Fix Faker::Source ruby language examples

### DIFF
--- a/lib/locales/en/source.yml
+++ b/lib/locales/en/source.yml
@@ -9,9 +9,7 @@ en:
         javascript: "console.log('faker_string_to_print');"
       print_1_to_10:
         ruby: "
-              10.times do |i|
-                print i
-              end"
+              [*1..10].each { |i| p i }"
         javascript: "
               for (let i=0; i<10; i++) {
                 console.log(i);

--- a/lib/locales/en/source.yml
+++ b/lib/locales/en/source.yml
@@ -2,10 +2,10 @@ en:
   faker:
     source:
       hello_world:
-        ruby: "print 'Hello World!'"
+        ruby: "p 'Hello World!'"
         javascript: "alert('Hello World!');"
       print:
-        ruby: "print 'faker_string_to_print'"
+        ruby: "p 'faker_string_to_print'"
         javascript: "console.log('faker_string_to_print');"
       print_1_to_10:
         ruby: "

--- a/lib/locales/en/source.yml
+++ b/lib/locales/en/source.yml
@@ -2,14 +2,14 @@ en:
   faker:
     source:
       hello_world:
-        ruby: "p 'Hello World!'"
+        ruby: "puts 'Hello World!'"
         javascript: "alert('Hello World!');"
       print:
-        ruby: "p 'faker_string_to_print'"
+        ruby: "puts 'faker_string_to_print'"
         javascript: "console.log('faker_string_to_print');"
       print_1_to_10:
         ruby: "
-              [*1..10].each { |i| p i }"
+              (1..10).each { |i| puts i }"
         javascript: "
               for (let i=0; i<10; i++) {
                 console.log(i);

--- a/test/test_faker_source.rb
+++ b/test/test_faker_source.rb
@@ -5,35 +5,35 @@ class TestFakerSource < Test::Unit::TestCase
     @tester = Faker::Source
   end
 
-  def test_hello_world
+  def test_hello_world_instance
     assert_instance_of String, @tester.hello_world
   end
 
-  def test_print
+  def test_hello_world
+    assert_match "'Hello World!'", @tester.hello_world
+  end
+
+  def test_print_instance
     assert_instance_of String, @tester.print
   end
 
-  def test_print_javascript
-    assert_equal "console.log('some string');", @tester.print(lang: :javascript)
+  def test_print
+    assert_match "'some string'", @tester.print
   end
 
   def test_print_another_string
-    assert_equal "print 'another string'", @tester.print(str: 'another string')
+    assert_match "'another string'", @tester.print(str: 'another string')
   end
 
   def test_print_invalid_lang
     assert_raise(I18n::MissingTranslationData) { @tester.print(lang: :js) }
   end
 
-  def test_print_1_to_10
+  def test_print_1_to_10_instance
     assert_instance_of String, @tester.print_1_to_10
   end
 
   def test_print_1_to_10_javascript
     assert_match 'console.log(i);', @tester.print_1_to_10(:javascript)
-  end
-
-  def test_print_1_to_10_matches
-    assert_match 'print i', @tester.print_1_to_10
   end
 end


### PR DESCRIPTION
# Fix 0 to 9 => 1 to 10

Ruby code

```
10.times do |i|
  puts i
end
```

Output

```
0123456789
```

Ruby code

```
[*1..10].each { |i| p i }
```

Output

```
1
2
3
4
5
6
7
8
9
10
```


# Ruby print method to p method

- print is not wrong but rubyist prefer use p or puts method
- p method output text and new line code on end of line

# Another

- Refactored test : not depends on just one kind programming language
