### PR TITLE
Rename Internet#user_name to #username

### DIFF
--- a/doc/internet.md
+++ b/doc/internet.md
@@ -19,17 +19,17 @@ Faker::Internet.safe_email #=> "christelle@example.org"
 Faker::Internet.safe_email('Nancy') #=> "nancy@example.net"
 
 # Optional arguments specifier=nil, separators=%w(. _)
-Faker::Internet.user_name #=> "alexie"
+Faker::Internet.username #=> "alexie"
 
-Faker::Internet.user_name('Nancy') #=> "nancy"
+Faker::Internet.username('Nancy') #=> "nancy"
 
-Faker::Internet.user_name('Nancy Johnson', %w(. _ -)) #=> "johnson-nancy"
+Faker::Internet.username('Nancy Johnson', %w(. _ -)) #=> "johnson-nancy"
 
 # Optional arguments: min_length=5, max_length=8
-Faker::Internet.user_name(5..8)
+Faker::Internet.username(5..8)
 
 # Optional argument min_length=8
-Faker::Internet.user_name(8)
+Faker::Internet.username(8)
 
 # Optional arguments: min_length=8, max_length=16
 Faker::Internet.password #=> "vg5msvy1uerg7"
@@ -66,7 +66,7 @@ Faker::Internet.ip_v6_cidr #=> "ac5f:d696:3807:1d72:2eb5:4e81:7d2b:e1df/78"
 Faker::Internet.mac_address #=> "e6:0d:00:11:ed:4f"
 Faker::Internet.mac_address('55:44:33') #=> "55:44:33:02:1d:9b"
 
-# Optional arguments: host=domain_name, path="/#{user_name}", scheme=scheme
+# Optional arguments: host=domain_name, path="/#{username}", scheme=scheme
 Faker::Internet.url #=> "http://thiel.com/chauncey_simonis"
 Faker::Internet.url('example.com') #=> "http://example.com/clotilde.swift"
 Faker::Internet.url('example.com', '/foobar.html') #=> "http://example.com/foobar.html"

--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -3,21 +3,21 @@ module Faker
     class << self
       def email(name = nil, *separators)
         if separators
-          [user_name(name, separators), domain_name].join('@')
+          [username(name, separators), domain_name].join('@')
         else
-          [user_name(name), domain_name].join('@')
+          [username(name), domain_name].join('@')
         end
       end
 
       def free_email(name = nil)
-        [user_name(name), fetch('internet.free_email')].join('@')
+        [username(name), fetch('internet.free_email')].join('@')
       end
 
       def safe_email(name = nil)
-        [user_name(name), 'example.' + sample(%w[org com net])].join('@')
+        [username(name), 'example.' + sample(%w[org com net])].join('@')
       end
 
-      def user_name(specifier = nil, separators = %w[. _])
+      def username(specifier = nil, separators = %w[. _])
         with_locale(:en) do
           return shuffle(specifier.scan(/\w+/)).join(sample(separators)).downcase if specifier.respond_to?(:scan)
           if specifier.is_a?(Integer)
@@ -26,7 +26,7 @@ module Faker
             tries = 0 # Don't try forever in case we get something like 1_000_000.
             result = nil
             loop do
-              result = user_name(nil, separators)
+              result = username(nil, separators)
               tries += 1
               break unless result.length < specifier && tries < 7
             end
@@ -35,7 +35,7 @@ module Faker
             tries = 0
             result = nil
             loop do
-              result = user_name(specifier.min, separators)
+              result = username(specifier.min, separators)
               tries += 1
               break unless !specifier.include?(result.length) && tries < 7
             end
@@ -165,7 +165,7 @@ module Faker
         "#{ip_v6_address}/#{rand(1..127)}"
       end
 
-      def url(host = domain_name, path = "/#{user_name}", scheme = 'http')
+      def url(host = domain_name, path = "/#{username}", scheme = 'http')
         "#{scheme}://#{host}#{path}"
       end
 
@@ -183,6 +183,8 @@ module Faker
         agents = vendor.respond_to?(:to_sym) && agent_hash[vendor.to_sym] || agent_hash[sample(agent_hash.keys)]
         sample(agents)
       end
+
+      alias user_name username
     end
   end
 end

--- a/lib/faker/twitter.rb
+++ b/lib/faker/twitter.rb
@@ -86,7 +86,7 @@ module Faker
       end
 
       def screen_name
-        Faker::Internet.user_name(nil, ['_'])[0...20]
+        Faker::Internet.username(nil, ['_'])[0...20]
       end
 
       private

--- a/test/test_faker_internet.rb
+++ b/test/test_faker_internet.rb
@@ -21,56 +21,60 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.safe_email.match(/.+@example.(com|net|org)/)
   end
 
-  def test_user_name
-    assert @tester.user_name(0..3).match(/[a-z]+((_|\.)[a-z]+)?/)
-    assert @tester.user_name.match(/[a-z]+((_|\.)[a-z]+)?/)
+  def test_username
+    assert @tester.username(0..3).match(/[a-z]+((_|\.)[a-z]+)?/)
+    assert @tester.username.match(/[a-z]+((_|\.)[a-z]+)?/)
   end
 
-  def test_user_name_with_string_arg
-    assert @tester.user_name('bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+  def test_user_name_alias
+    assert_equal @tester.method(:username), @tester.method(:user_name)
   end
 
-  def test_user_name_with_string_arg_determinism
-    deterministically_verify -> { @tester.user_name('bo peep') }, depth: 4 do |subject|
+  def test_username_with_string_arg
+    assert @tester.username('bo peep').match(/(bo(_|\.)peep|peep(_|\.)bo)/)
+  end
+
+  def test_username_with_string_arg_determinism
+    deterministically_verify -> { @tester.username('bo peep') }, depth: 4 do |subject|
       assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
     end
   end
 
-  def test_user_name_with_integer_arg
+  def test_username_with_integer_arg
     (1..32).each do |min_length|
-      assert @tester.user_name(min_length).length >= min_length
+      assert @tester.username(min_length).length >= min_length
     end
   end
 
-  def test_user_name_with_very_large_integer_arg
-    exception = assert_raises(ArgumentError) { @tester.user_name(10_000_000) }
+  def test_username_with_very_large_integer_arg
+    exception = assert_raises(ArgumentError) { @tester.username(10_000_000) }
     assert_equal('Given argument is too large', exception.message)
   end
 
-  def test_user_name_with_closed_range_arg
+  def test_username_with_closed_range_arg
     (1..32).each do |min_length|
       (min_length..32).each do |max_length|
-        l = @tester.user_name((min_length..max_length)).length
+        l = @tester.username((min_length..max_length)).length
         assert l >= min_length
         assert l <= max_length
       end
     end
   end
 
-  def test_user_name_with_open_range_arg
+  def test_username_with_open_range_arg
     (1..32).each do |min_length|
       (min_length + 1..33).each do |max_length|
-        l = @tester.user_name((min_length...max_length)).length
+        l = @tester.username((min_length...max_length)).length
         assert l >= min_length
         assert l <= max_length - 1
       end
     end
   end
 
-  def test_user_name_with_range_and_separators
+  def test_username_with_range_and_separators
     (1..32).each do |min_length|
       (min_length + 1..33).each do |max_length|
-        u = @tester.user_name((min_length...max_length), %w[=])
+        u = @tester.username((min_length...max_length), %w[=])
         assert u.length.between? min_length, max_length - 1
         assert u.match(/\A[a-z]+((=)?[a-z]*)*\z/)
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,7 @@ I18n.enforce_available_locales = true
 # @param random [Integer] A random number seed; Used to override the default.
 #
 # @example
-#   deterministically_verify ->{ @tester.user_name('bo peep') } do |subject|
+#   deterministically_verify ->{ @tester.username('bo peep') } do |subject|
 #     assert subject.match(/(bo(_|\.)peep|peep(_|\.)bo)/)
 #   end
 #


### PR DESCRIPTION
Call me pedantic, but this—by far—has always been my biggest gripe with Faker. "Username" is the more typical and standardized spelling. I always seem to end up with code like this:

```
User.new(
  username: Faker::Internet.user_name,
  password: Faker::Internet.password,
)
```

Having to remember that difference for this one library (and put up with the misalignment to boot :wink:) is a constant source of frustration. Here's what that code would look like now:

```
User.new(
  username: Faker::Internet.username,
  password: Faker::Internet.password,
)
```

Ah, much improved!

I've added an alias to maintain backwards compatibility.