### PR TITLE
Add Faker::UniqueGenerator - exclude method

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ Faker::Name.unique.clear # Clears used values for Faker::Name
 Faker::UniqueGenerator.clear # Clears used values for all generators
 ```
 
+You also can give some already used values to the unique generator if you have
+collisions with the generated data (i.e: using FactoryBot with random and
+manually set values).
+
+```ruby
+# Usage:
+# Faker::<generator>.unique.exclude(method, arguments, list)
+
+# Add 'azerty' and 'wxcvbn' to the string generator with 6 char length
+Faker::Lorem.unique.exclude :string, [6], %w[azerty wxcvbn]
+```
+
 ### Deterministic Random
 
 Faker supports seeding of its pseudo-random number generator (PRNG) to provide deterministic output of repeated method calls.

--- a/lib/helpers/unique_generator.rb
+++ b/lib/helpers/unique_generator.rb
@@ -34,5 +34,12 @@ module Faker
     def self.clear
       ObjectSpace.each_object(self, &:clear)
     end
+
+    def exclude(name, arguments, values)
+      values ||= []
+      values.each do |value|
+        @previous_results[[name, arguments]] << value
+      end
+    end
   end
 end

--- a/test/test_faker_lorem.rb
+++ b/test/test_faker_lorem.rb
@@ -114,4 +114,10 @@ class TestFakerLorem < Test::Unit::TestCase
     paragraph = @tester.paragraph_by_chars(256)
     assert(paragraph.length == 256)
   end
+
+  def test_unique_with_already_set_values
+    values = ('a'..'z').to_a + ('0'..'9').to_a
+    @tester.unique.exclude(:character, [], values)
+    assert_raise(Faker::UniqueGenerator::RetryLimitExceeded) { @tester.unique.character }
+  end
 end


### PR DESCRIPTION
This adds an  "add_to_previous_results" method to `UniqueGenerator`, allowing to manually specify already used values, or excluded ones.

On a Rails app, I had collisions in the tests with manually defined values and the ones created by faker. I guess there are other use cases where having this feature could be useful.

I think the test speaks for itself:

```ruby
def test_unique_with_already_set_values
  values = ('a'..'z').to_a + ('0'..'9').to_a
  @tester.unique.add_to_previous_results(:character, [], values)
  assert_raise(Faker::UniqueGenerator::RetryLimitExceeded) { @tester.unique.character }
end
```

- [x] Rubocop
- [x] Documentation
- [x] New test
- [x] Tests passing

I can change the method name if it's not understandable.