### PR TITLE
Update docs on behavior of price

### DIFF
--- a/doc/commerce.md
+++ b/doc/commerce.md
@@ -12,8 +12,8 @@ Faker::Commerce.material #=> "Steel"
 
 Faker::Commerce.product_name #=> "Practical Granite Shirt"
 
-Faker::Commerce.price #=> "44.6"
-Faker::Commerce.price(range = 0..10.0, as_string = false) #=> "2.18"
+Faker::Commerce.price #=> 44.6
+Faker::Commerce.price(range = 0..10.0, as_string = true) #=> "2.18"
 
 # Generate a random promotion code.
 # Optional argument digits = 6 for number of random digits in suffix


### PR DESCRIPTION
The default for Faker::Comerce.price is a Float. Fixup docs to reflect that. 

```
irb(main):007:0> Faker::Commerce.price
=> 47.06
irb(main):008:0> Faker::Commerce.price(range = 0..10.0, as_string = false)
=> 0.45
irb(main):009:0> Faker::Commerce.price(range = 0..10.0, as_string = true)
=> "4.85"
irb(main):010:0> Faker::Commerce.price.class
=> Float
```