### PR TITLE
Fix Company.luhn_algorithm and add missing tests.

### DIFF
--- a/lib/faker/company.rb
+++ b/lib/faker/company.rb
@@ -178,7 +178,7 @@ module Faker
       def luhn_algorithm(number)
         multiplications = []
 
-        number.split(//).each_with_index do |digit, i|
+        number.reverse.split(//).each_with_index do |digit, i|
           multiplications << if i.even?
                                digit.to_i * 2
                              else

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -180,9 +180,11 @@ class TestFakerCompany < Test::Unit::TestCase
   end
 
   def luhn_checksum(luhn)
-    luhn.each_char.map(&:to_i).reverse.each_with_index.map do |n, i|
+    luhn_split = luhn.each_char.map(&:to_i).reverse.each_with_index.map do |n, i|
       x = i.odd? ? n * 2 : n
       x > 9 ? x - 9 : x
-    end.compact.sum
+    end
+
+    luhn_split.compact.inject(0) { |sum, x| sum + x }
   end
 end

--- a/test/test_faker_company.rb
+++ b/test/test_faker_company.rb
@@ -144,6 +144,21 @@ class TestFakerCompany < Test::Unit::TestCase
     )
   end
 
+  def test_luhn_algorithm
+    # Odd length base for luhn algorithm
+    odd_base = Faker::Number.number([5, 7, 9, 11, 13].sample)
+    odd_luhn_complement = @tester.send(:luhn_algorithm, odd_base)
+    odd_control = "#{odd_base}#{odd_luhn_complement}"
+
+    # Even length base for luhn algorithm
+    even_base = Faker::Number.number([4, 6, 8, 10, 12].sample)
+    even_luhn_complement = @tester.send(:luhn_algorithm, even_base)
+    even_control = "#{even_base}#{even_luhn_complement}"
+
+    assert((luhn_checksum(odd_control) % 10).zero?)
+    assert((luhn_checksum(even_control) % 10).zero?)
+  end
+
   private
 
   def czech_o_n_checksum(org_no)
@@ -162,5 +177,12 @@ class TestFakerCompany < Test::Unit::TestCase
     abn.split('').map(&:to_i).each_with_index.map do |n, i|
       (i.zero? ? n - 1 : n) * abn_weights[i]
     end.inject(:+)
+  end
+
+  def luhn_checksum(luhn)
+    luhn.each_char.map(&:to_i).reverse.each_with_index.map do |n, i|
+      x = i.odd? ? n * 2 : n
+      x > 9 ? x - 9 : x
+    end.compact.sum
   end
 end


### PR DESCRIPTION
There is some issues with Faker::Company.luhn_algorithm(number) : 
- Generates non "luhn-compliant" strings for even length `number`
- Not tested

The problem was that `luhn_algorithm` didn't reverse the `number` submitted argument before splitting it (as [it should](https://en.wikipedia.org/wiki/Luhn_algorithm#Description)).

This forgotten reverse resulted in the generation of non "luhn-compliant" strings for even length `number`.

|                                              index | 0 |*1*| 2 |*3*| 4 |*5*|
|----------------------------------------------------|---|---|---|---|---|---|
| odd_base                                           | 9 | 8 | 4 | 5 | 6 |   |
| reserved_odd_base                                  | 6 | 5 | 4 | 8 | 9 |   |
| selected numbers for odd_base *2 by luh_algorithm  | 9 |   | 4 |   | 6 |   |
| right numbers for odd_base *2 by luh_algorithm     | 6 |   | 4 |   | 9 |   |
|                                                    |   |   |   |   |   |   |
| even_base                                          | 8 | 7 | 6 | 9 | 4 | 3 |
| reserved_even_base                                 | 3 | 4 | 9 | 6 | 7 | 8 |
| selected numbers for even_base *2 by luh_algorithm | 8 |   | 6 |   | 4 |   |
| right numbers for even_base *2 by luh_algorithm    |__3__| |__9__| |__7__| |

No issue for odd length arguments ([9,4,6] vs [6,4,9]), only with even ([8,6,4] vs [3,9,7]).

This commit fixes the issue and add `test_luhn_algorithm` to avoid future issues.