### PR TITLE
Add Faker::File.dir

### DIFF
--- a/doc/default/file.md
+++ b/doc/default/file.md
@@ -11,5 +11,11 @@ Faker::File.mime_type #=> "application/pdf"
 Faker::File.file_name('path/to') #=> "path/to/something_random.jpg"
 Faker::File.file_name('foo/bar', 'baz') #=> "foo/bar/baz.zip"
 Faker::File.file_name('foo/bar', 'baz', 'doc') #=> "foo/bar/baz.doc"
-Faker::File.file_name('foo/bar', 'baz', 'mp3', '\') #=> "foo\bar\baz.mp3"
+Faker::File.file_name('foo/bar', 'baz', 'mp3', '\\') #=> "foo\bar\baz.mp3"
+
+# Optional arguments: segment_count, root, directory_separator
+Faker::File.dir #=> "path/to/something_random"
+Faker::File.dir(2) #=> "foo/bar"
+Faker::File.dir(3, '/') #=> "/foo/bar/baz"
+Faker::File.dir(3, nil, '\\') #=> "foo\bar\baz"
 ```

--- a/doc/unreleased/default/file.md
+++ b/doc/unreleased/default/file.md
@@ -11,5 +11,11 @@ Faker::File.mime_type #=> "application/pdf"
 Faker::File.file_name('path/to') #=> "path/to/something_random.jpg"
 Faker::File.file_name('foo/bar', 'baz') #=> "foo/bar/baz.zip"
 Faker::File.file_name('foo/bar', 'baz', 'doc') #=> "foo/bar/baz.doc"
-Faker::File.file_name('foo/bar', 'baz', 'mp3', '\') #=> "foo\bar\baz.mp3"
+Faker::File.file_name('foo/bar', 'baz', 'mp3', '\\') #=> "foo\bar\baz.mp3"
+
+# Optional arguments: segment_count, root, directory_separator
+Faker::File.dir #=> "path/to/something_random"
+Faker::File.dir(2) #=> "foo/bar"
+Faker::File.dir(3, '/') #=> "/foo/bar/baz"
+Faker::File.dir(3, nil, '\\') #=> "foo\bar\baz"
 ```

--- a/lib/faker/default/file.rb
+++ b/lib/faker/default/file.rb
@@ -3,6 +3,15 @@
 module Faker
   class File < Base
     class << self
+      def dir(segment_count = 3, root = nil, directory_separator = '/')
+        Array
+          .new(segment_count) { Faker::Internet.slug }
+          .unshift(root)
+          .compact
+          .join(directory_separator)
+          .squeeze(directory_separator)
+      end
+
       def extension
         fetch('file.extension')
       end
@@ -12,7 +21,7 @@ module Faker
       end
 
       def file_name(dir = nil, name = nil, ext = nil, directory_separator = '/')
-        dir ||= Faker::Internet.slug
+        dir ||= dir(1)
         name ||= Faker::Lorem.word.downcase
         ext ||= extension
 

--- a/test/faker/default/test_faker_file.rb
+++ b/test/faker/default/test_faker_file.rb
@@ -16,6 +16,18 @@ class TestFakerFile < Test::Unit::TestCase
   end
 
   def test_file_name
-    assert @tester.file_name.match(%r{([a-z\-_]+)(\\|\/)([a-z\-_]+)\.([a-z]+)})
+    assert @tester
+      .file_name
+      .match(%r{^([a-z\-_.]+)(\\|\/)([a-z\-_]+)\.([a-z]+)$})
+  end
+
+  def test_dir
+    assert @tester.dir.match(%r{^(([a-z\-_.]+)(\\|\/)){2}([a-z\-_.]+)$})
+  end
+
+  def test_dir_with_args
+    assert @tester
+      .dir(2, '\\root\\', '\\')
+      .match(%r{^\\root(\\([a-z\-_.]+)){2}$})
   end
 end


### PR DESCRIPTION
Add Faker::File.dir for generating directory paths.

I'd like to take this further, but I think the ideal naming would break backwards compatibility. Anyways, here's what I have in mind:

- `Faker:File.dir` — as implemented in this PR
- `Faker:File.file_name` — returns just the name part of the path (**breaking change** since the existing `.file_name` also returns a path segment)
- `Faker:File.path` — returns a `.dir` with a `.file_name` (basically like the current `.file_name`)

Let me know any thoughts on this and how we might be able to move forward.