### PR TITLE
Change determinism tests to get the class name of namespaces

### DIFF
--- a/lib/faker/games.rb
+++ b/lib/faker/games.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Faker
-  module Games
-  end
-end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -44,8 +44,9 @@ class TestDeterminism < Test::Unit::TestCase
   end
 
   def subclasses
-    Faker.constants.delete_if do |subclass|
-      %i[Base Bank Char Base58 ChileRut Config Date Games GamesHalfLife Internet Time VERSION].include?(subclass)
+    subclasses = Faker.constants.select { |constant| Faker.const_get(constant).is_a? Class }
+    subclasses.delete_if do |subclass|
+      %i[Base Bank ChileRut Config Date GamesHalfLife Internet Time].include?(subclass)
     end.sort
   end
 

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -46,7 +46,7 @@ class TestDeterminism < Test::Unit::TestCase
   def subclasses
     subclasses = Faker.constants.select { |constant| Faker.const_get(constant).is_a? Class }
     subclasses.delete_if do |subclass|
-      %i[Base Bank ChileRut Config Date GamesHalfLife Internet Time].include?(subclass)
+      %i[Bank ChileRut Config Date Internet Time].include?(subclass)
     end.sort
   end
 


### PR DESCRIPTION
`Faker.constants` returns all constants in Faker. This includes, but is not limited to, class names. If you want only class names, you can use `Faker.constants.select {|c| Faker.const_get(c).is_a? Class}`

When we started introducing namespaces, we needed to exclude the parent module in the determinist test because `Faker.constants` is also including the nested module. I mean: `Faker.constants` would return `Games` and `HalfLife` because of `Faker::Games::HalfLife` and we just want to test the subclasses. [Reference](https://github.com/stympy/faker/pull/1381/files#diff-25ef3f8edb30110c19f67fb2bd00df7fL46).

This should allow us to keep testing the old format `Module::Class` as well as the new namespacing format `Module::Module::Class`