### PR TITLE
Add DC Comics titles

### DIFF
--- a/doc/dc_comics.md
+++ b/doc/dc_comics.md
@@ -12,4 +12,6 @@ Faker::DcComics.heroine #=> "Supergirl"
 Faker::DcComics.villain #=> "The Joker"
 
 Faker::DcComics.name #=> "Clark Kent"
+
+Faker::DcComics.title #=> "Teen Titans: The Judas Contract
 ```

--- a/lib/faker/dc_comics.rb
+++ b/lib/faker/dc_comics.rb
@@ -17,5 +17,9 @@ module Faker
     def self.name
       fetch('dc_comics.name')
     end
+
+    def self.title
+      fetch('dc_comics.title')
+    end
   end
 end

--- a/lib/locales/en/dc_comics.yml
+++ b/lib/locales/en/dc_comics.yml
@@ -37,3 +37,16 @@ en:
       "Ray Palmer", "Ted Kord", "Connor Hawke", "Terry McGinnis", "Harvey Bullock",
       "Al Pratt", "Wesley Dodds", "Maxwell Lord", "Oswald Cobblepot", "Alfred Pennyworth"
       ]
+      title: [
+      "The Sinestro Corps War", "The Coyote Gospel", "Green Arrow: The Longbow Hunters",
+      "Jla: Earth 2 ", "Identity Crisis", "Jla: Tower Of Babel", "Superman For All Seasons",
+      "Superman: Red Son", "Batman: The Long Halloween", "Swamp Thing: The Anatomy Lesson",
+      "For The Man Who Has Everything", "Jack Kirby'S New Gods",
+      "Arkham Asylum: A Serious House On Serious Earth", "Snowbirds Don't Fly",
+      "Whatever Happened To The Man Of Tomorrow?", "The Killing Joke",
+      "Teen Titans: The Judas Contract", "The New Frontier",
+      "Kingdom Come", "Crisis On Infinite Earths",
+      "Batman: Year One", "All Star Superman", "The Dark Knight Returns",
+      "Multiversity", "Gotham Central", "Grant Morrison'S Animal Man",
+      "Doom Patrol", "Action Comics", "Detective Comics"
+      ]

--- a/test/test_faker_dc_comics.rb
+++ b/test/test_faker_dc_comics.rb
@@ -22,4 +22,8 @@ class TestFakerDcComics < Test::Unit::TestCase
   def test_name
     assert @tester.name.match(/\w+/)
   end
+
+  def test_title
+    assert @tester.title.match(/(\w+\.? ?){2,3}/)
+  end
 end


### PR DESCRIPTION
Make DC Comics module more rich, by adding the titles, such as the `book` module does.

The Titles list was based of the most popular and [acclaimed works by the publisher](https://www.complex.com/pop-culture/the-best-dc-comics-of-all-time/all-star-superman).