### PR TITLE
Add Faker::Games::SonicTheHedgehog.game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - [PR #1246](https://github.com/stympy/faker/pull/1246) Store list of generators with enabled uniqueness for faster clear [@MarcPer](https://github.com/MarcPer)
 
 ### Update/add locales
+- [PR #1428](https://github.com/stympy/faker/pull/1428) Add Faker::Games::SonicTheHedgehog.game [@boardfish](https://github.com/boardfish)
 - [PR #1415](https://github.com/stympy/faker/pull/1415) Add new Overwatch items [@lucasqueiroz](https://github.com/lucasqueiroz)
 - [PR #1407](https://github.com/stympy/faker/pull/1407) Add more data for Faker::Friends [@JIntrocaso](https://github.com/JIntrocaso)
 - [PR #1402](https://github.com/stympy/faker/pull/1402) Update heroes_of_the_storm.yml [@eddorre](https://github.com/eddorre)

--- a/doc/sonic_the_hedgehog.md
+++ b/doc/sonic_the_hedgehog.md
@@ -6,4 +6,7 @@ Faker::Games::SonicTheHedgehog.character #=> "Sonic the Hedgehog"
 
 # Any zone from the series
 Faker::Games::SonicTheHedgehog.zone #=> "The Legend of Zelda Zone"
+
+# Any game from the franchise
+Faker::Games::SonicTheHedgehog.game #=> "Waku Waku Sonic Patrol Car"
 ```

--- a/lib/faker/games/sonic_the_hedgehog.rb
+++ b/lib/faker/games/sonic_the_hedgehog.rb
@@ -11,6 +11,10 @@ module Faker
         def zone
           fetch('games.sonic_the_hedgehog.zone')
         end
+
+        def game
+          fetch('games.sonic_the_hedgehog.game')
+        end
       end
     end
   end

--- a/lib/locales/en/sonic_the_hedgehog.yml
+++ b/lib/locales/en/sonic_the_hedgehog.yml
@@ -283,3 +283,128 @@ en:
           - ZERO
           - Zomom
           - Zor
+        game:
+          - Sonic the Hedgehog
+          - Sonic the Hedgehog
+          - Sonic the Hedgehog 2
+          - Sonic the Hedgehog 2
+          - Sonic the Hedgehog Spinball
+          - Sonic the Hedgehog CD
+          - Sonic Chaos
+          - Sonic the Hedgehog 3
+          - Sonic & Knuckles
+          - Sonic the Hedgehog Triple Trouble
+          - Knuckles' Chaotix
+          - Tails' Skypatrol
+          - Tails Adventure
+          - Sonic Labyrinth
+          - Sonic Blast
+          - Sonic Advance
+          - Sonic Advance 2
+          - Sonic Advance 3
+          - Sonic Rush
+          - Sonic Rivals
+          - Sonic Rush Adventure
+          - Sonic Rivals 2
+          - "Sonic the Hedgehog 4: Episode I"
+          - Sonic Colors
+          - Sonic Generations
+          - "Sonic the Hedgehog 4: Episode II"
+          - Sonic Jump
+          - "Sonic Boom: Shattered Crystal"
+          - "Sonic Boom: Fire & Ice"
+          - Sonic Mania
+          - Sonic Mania Plus (2018) 
+          - SegaSonic the Hedgehog
+          - Sonic 3D Blast
+          - Sonic Adventure
+          - Sonic Adventure 2
+          - Sonic Heroes
+          - Shadow the Hedgehog
+          - Sonic the Hedgehog
+          - Sonic and the Secret Rings
+          - Sonic Unleashed
+          - Sonic and the Black Knight
+          - Sonic Colors
+          - Sonic Generations
+          - Sonic Lost World
+          - "Sonic Boom: Rise of Lyric"
+          - Sonic Forces
+          - Sonic Eraser
+          - Dr. Robotnik's Mean Bean Machine
+          - Sonic the Hedgehog's Gameworld
+          - Sonic Labyrinth
+          - Sonic Shuffle
+          - Sonic Pinball Party
+          - Sega Superstars
+          - Sonic and the Secret Rings
+          - Mario & Sonic at the Olympic Games
+          - Sega Superstars Tennis
+          - Mario & Sonic at the Olympic Winter Games
+          - Mario & Sonic at the London 2012 Olympic Games
+          - Mario & Sonic at the Sochi 2014 Olympic Winter Games
+          - Mario & Sonic at the Rio 2016 Olympic Games (2016) 
+          - Waku Waku Sonic Patrol Car
+          - SegaSonic Cosmo Fighter
+          - Sonic Drift
+          - Sonic Drift 2
+          - Sonic R
+          - Sonic Riders
+          - Sonic Rivals
+          - Sonic Rivals 2
+          - "Sonic Riders: Zero Gravity"
+          - Sonic & Sega All-Stars Racing
+          - Sonic Free Riders
+          - Sonic & All-Stars Racing Transformed
+          - "Sonic Forces: Speed Battle"
+          - Wacky Worlds Creativity Studio
+          - Tails and the Music Maker
+          - Sonic the Hedgehog's Gameworld
+          - Sonic's Schoolhouse
+          - Sonic X
+          - Sonic the Fighters
+          - Sonic Battle
+          - Super Smash Bros. Brawl
+          - Super Smash Bros. for Nintendo 3DS and Wii U
+          - Sonic Battle
+          - "Sonic Chronicles: The Dark Brotherhood"
+          - Mario & Sonic at the Olympic Winter Games
+          - Mario & Sonic at the London 2012 Olympic Games
+          - Sonic Dash
+          - Sonic Runners
+          - "Sonic Dash 2: Sonic Boom"
+          - Sonic Runners Adventure
+          - Sonic the Hedgehog 3D Chess
+          - Sonic Monopoly
+          - Sonic Boom Monopoly
+          - Sonic the Hedgehog Spinball
+          - Dr. Robotnik's Mean Bean Machine
+          - Sonic 2 in 1
+          - Sonic Compilation
+          - Sonic CD
+          - "Sonic 3D Blast: Flickies' Island"
+          - Sonic Blast
+          - Sonic & Knuckles Collection
+          - Sonic Jam
+          - Sonic R
+          - Sonic the Hedgehog Pocket Adventure
+          - "Sonic Adventure 2: Battle"
+          - Sonic Mega Collection
+          - Sonic N
+          - "Sonic Adventure DX: Director's Cut"
+          - Sonic Heroes
+          - Sonic Gems Collection
+          - Sonic the Hedgehog Genesis
+          - Sega Genesis Collection
+          - Sonic's Ultimate Genesis Collection
+          - Sonic Classic Collection
+          - Sonic & Sega All-Stars Racing Arcade
+          - Sonic the Fighters
+          - 3D Sonic the Hedgehog
+          - Sonic the Hedgehog
+          - Sonic the Hedgehog 2
+          - 3D Sonic the Hedgehog 2
+          - Sega 3D Classics Collection
+          - Team Sonic Racing
+          - Super Smash Bros. Ultimate
+          - Sega Heroes 

--- a/lib/locales/en/sonic_the_hedgehog.yml
+++ b/lib/locales/en/sonic_the_hedgehog.yml
@@ -407,4 +407,4 @@ en:
           - Sega 3D Classics Collection
           - Team Sonic Racing
           - Super Smash Bros. Ultimate
-          - Sega Heroes 
+          - Sega Heroes

--- a/test/test_faker_sonic_the_hedgehog.rb
+++ b/test/test_faker_sonic_the_hedgehog.rb
@@ -14,4 +14,8 @@ class TestFakerGamesSonicTheHedgehog < Test::Unit::TestCase
   def test_zone
     assert @tester.zone.match(/\w+/)
   end
+
+  def test_game
+    assert @tester.game.match(/\w+/)
+  end
 end


### PR DESCRIPTION
Adds all games (not including those cancelled) to `Faker::Games::SonicTheHedgehog`, as listed at [this wiki page](http://sonic.wikia.com/wiki/List_of_games).