### PR TITLE
Add Maroon 5 and Paramore to music

### DIFF
--- a/lib/locales/en/music.yml
+++ b/lib/locales/en/music.yml
@@ -11,9 +11,9 @@ en:
       "Frank Zappa", "Frightened Rabbit", "George Michael", "Grace Jones", "Green Day", "Guns N' Roses", "Herbie Hancock", "Horace Silver", "Hugh Masekela", "Ian Dury", "Iggy Pop",
       "The Jam", "James Brown", "Jeff Beck", "Jeff Buckley", "Jimi Hendrix", "John Coltrane", "John Lydon", "Johnny Borrell", "Johnny Cash", "Johnny Marr", "Joni Mitchell", "Joy Division",
       "K.D Lang", "Kasabian", "Kate Bush", "Keith Moon", "Keith Richards", "The Kinks", "Kiss", "The La's", "Led Zeppelin", "Lenny Kravitz", "Leonard Cohen", "Liam Gallagher",
-      "The Libertines", "Madness", "Madonna", "Manic Street Preachers", "Marc Bolan", "Marianne Faithfull", "Marilyn Manson", "The Mars Volta", "Max Roach", "Michael Jackson",
+      "The Libertines", "Madness", "Madonna", "Manic Street Preachers", "Marc Bolan", "Marianne Faithfull", "Marilyn Manson", "Maroon 5", "The Mars Volta", "Max Roach", "Michael Jackson",
       "Miles Davis", "Morrissey", "Muddy Waters", "Mumford and Sons", "Muse", "Neil Young", "New Order", "Nick Cave", "Nigel Kennedy", "Nina Simone", "Nirvana", "Noel Gallagher",
-      "O.A.R.", "Oasis", "Offspring", "Ozzy Osbourne", "Pat Metheny", "Patti Smith", "Paul Weller", "Pearl Jam", "Pete Townshend", "Phil Collins", "Phish", "Pink Floyd", "PJ Harvey",
+      "O.A.R.", "Oasis", "Offspring", "Ozzy Osbourne", "Paramore", "Pat Metheny", "Patti Smith", "Paul Weller", "Pearl Jam", "Pete Townshend", "Phil Collins", "Phish", "Pink Floyd", "PJ Harvey",
       "The Police", "The Pretenders", "Primal Scream", "Prince", "Program The Dead", "Pulp", "Queen", "Radiohead", "The Ramones", "Red Hot Chili Peppers", "R.E.M.", "Rick Wright",
       "Rod Stewart", "The Rolling Stones", "Rory Gallagher", "Roxy Music", "Roy Hargrove", "Rufus Wainwright", "Run-D.M.C.", "Ryan Adams", "Sex Pistols", "Simply Red",
       "Sinead O'connor", "Siouxsie and The Banshees", "The Slits", "The Smiths", "Sonic Youth", "The Specials", "Squeeze", "Status Quo", "Stereophonics", "Stone Roses",
@@ -28,5 +28,5 @@ en:
       "(What's the Story) Morning Glory?", "The Marshall Mathers LP", "Like a Virgin", "Cross Road", "25", "Boston", "Oops!... I Did It Again", "The Colour of My Love", "Hysteria", "Faith",
       "Dookie", "Can't Slow Down", "Daydream", "HIStory: Past", " Present and Future", " Book I", "Off the Wall", "The Woman in Me", "Breakfast in America", "Tracy Chapman",
       "Flashdance: Original Soundtrack from the Motion Picture", "Whitney", "Confessions", "X&Y", "High School Musical", "High School Musical 2", "Viva la Vida or Death and All His Friends",
-      "I Dreamed a Dream", "Recovery", "Midnight Memories", "Frozen", "Lemonade"]
+      "I Dreamed a Dream", "Recovery", "Midnight Memories", "Frozen", "Lemonade", "Brand New Eyes", "All We Know Is Falling", "Riot!", "Songs About Jane", "Hands All Over"]
       genres: ["Rock", "Pop", "Electronic", "Folk", "World", "Country", "Jazz", "Funk", "Soul", "Hip Hop", "Classical", "Latin", "Reggae", "Stage And Screen", "Blues", "Non Music", "Rap"]


### PR DESCRIPTION
This adds the bands `Paramore` and `Maroon 5` to the `music` locale.
Some of their more prominent albums were also added.

Source of album names:
* https://en.wikipedia.org/wiki/Paramore_discography
* https://en.wikipedia.org/wiki/Maroon_5_discography

```ruby
<<~FANDOM
  Looking forward to see paramore and maroon 5 in my generated test data <3
FANDOM
```