### PR TITLE
Format brazilian citizen number

### DIFF
--- a/doc/unreleased/id_number.md
+++ b/doc/unreleased/id_number.md
@@ -22,5 +22,5 @@ Faker::IDNumber.valid_south_african_id_number #=> "8105128870184"
 Faker::IDNumber.invalid_south_african_id_number #=> "1642972065088"
 
 # Generate a Brazilian citizen number (CPF)
-Faker::IDNumber.brazilian_citizen_number #=> "53540542221"
+Faker::IDNumber.brazilian_citizen_number #=> "535.405.422-21"
 ```

--- a/lib/faker/id_number.rb
+++ b/lib/faker/id_number.rb
@@ -79,7 +79,7 @@ module Faker
         digits = Faker::Number.leading_zero_number(9) until digits&.match(/(\d)((?!\1)\d)+/)
         first_digit = brazilian_citizen_number_checksum_digit(digits)
         second_digit = brazilian_citizen_number_checksum_digit(digits + first_digit)
-        [digits, first_digit, second_digit].join
+        "#{digits.gsub(/(\d{3})(?=\d)/, '\1.')}-#{first_digit}#{second_digit}"
       end
 
       private

--- a/test/test_faker_id_number.rb
+++ b/test/test_faker_id_number.rb
@@ -64,7 +64,7 @@ class TestFakerIdNumber < Test::Unit::TestCase
   end
 
   def test_brazilian_citizen_number
-    sample = @tester.brazilian_citizen_number
+    sample = @tester.brazilian_citizen_number.gsub(/\.|-/, '')
     assert_match(/^\d{11}$/, sample)
     assert_match(/(\d)((?!\1)\d)+/, sample)
     digit_sum = sample[0..8].chars.each_with_index.inject(0) do |acc, (digit, i)|


### PR DESCRIPTION
Show Brazilian citizen number formatted, like we do for other IDs (eg. SSN and Spanish ID)