### PR TITLE
Faker::Internet.slug excludes "." by default

### DIFF
--- a/lib/faker/internet.rb
+++ b/lib/faker/internet.rb
@@ -174,7 +174,7 @@ module Faker
       end
 
       def slug(words = nil, glue = nil)
-        glue ||= sample(%w[- _ .])
+        glue ||= sample(%w[- _])
         (words || Faker::Lorem.words(2).join(' ')).delete(',.').gsub(' ', glue).downcase
       end
 


### PR DESCRIPTION
Fixes https://github.com/stympy/faker/issues/838.

To avoid errors caused by misinterpreting dotted strings as filename extensions, omit `.` as a delimiter for randomly generated slugs.

Note I omitted test coverage here since it would require looping around the randomization.