### PR TITLE
Fixed documentation for Faker::Internet.password

### DIFF
--- a/doc/v1.9.1/internet.md
+++ b/doc/v1.9.1/internet.md
@@ -32,11 +32,11 @@ Faker::Internet.username(5..8)
 Faker::Internet.username(8)
 
 # Optional arguments: min_length=8, max_length=16
-Faker::Internet.password #=> "vg5msvy1uerg7"
+Faker::Internet.password #=> "Vg5mSvY1UeRg7"
 
-Faker::Internet.password(8) #=> "yfgjik0hgzdqs0"
+Faker::Internet.password(8) #=> "YfGjIk0hGzDqS0"
 
-Faker::Internet.password(10, 20) #=> "eoc9shwd1hwq4vbgfw"
+Faker::Internet.password(10, 20) #=> "EoC9ShWd1hWq4vBgFw"
 
 Faker::Internet.password(10, 20, true) #=> "3k5qS15aNmG"
 


### PR DESCRIPTION
The optional parameter for mix_case is true, so the documentation was not correct. Maybe the default should be false?