### PR TITLE
Add support to formatted brazilian_citizen_number and brazilian_company_number

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Lint/UnifiedInteger:
   Enabled: false
 
 Metrics/AbcSize:
-  Description: This cop checks that the ABC size of methods is not higher than the configured maximum. 
+  Description: This cop checks that the ABC size of methods is not higher than the configured maximum.
   Enabled: false
 
 Metrics/BlockLength:
@@ -18,7 +18,7 @@ Metrics/BlockLength:
   Enabled: false
 
 Metrics/ClassLength:
-  Description: This cop checks if the length a class exceeds some maximum value. 
+  Description: This cop checks if the length a class exceeds some maximum value.
   Enabled: false
 
 Metrics/CyclomaticComplexity:
@@ -28,11 +28,11 @@ Metrics/CyclomaticComplexity:
   Max: 6
 
 Metrics/LineLength:
-  Description: This cop checks the length of lines in the source code. The maximum length is configurable. 
+  Description: This cop checks the length of lines in the source code. The maximum length is configurable.
   Enabled: false
 
 Metrics/MethodLength:
-  Description: This cop checks if the length of a method exceeds some maximum value. 
+  Description: This cop checks if the length of a method exceeds some maximum value.
   Enabled: false
 
 Metrics/PerceivedComplexity:
@@ -52,6 +52,12 @@ Style/EvalWithLocation:
   Description: This cop checks eval method usage. eval can receive source location metadata, that are filename and line number.
   Exclude:
     - 'lib/faker/default/json.rb'
+
+Style/FormatStringToken:
+  Description: This cop checks for a consistent style for named format string tokens.
+  Exclude:
+    - 'lib/faker/default/company.rb'
+    - 'lib/faker/default/id_number.rb'
 
 Style/FrozenStringLiteralComment:
   Description: Add the frozen_string_literal comment to the top of files to help transition from Ruby 2.3.0 to Ruby 3.0.

--- a/doc/unreleased/default/company.md
+++ b/doc/unreleased/default/company.md
@@ -59,4 +59,7 @@ Faker::Company.south_african_trust_registration_number #=> "IT38/6489900"
 
 # Generate a Brazilian company number (CNPJ)
 Faker::Company.brazilian_company_number #=> "18553414000618"
+
+# Generate a formatted Brazilian company number (CNPJ)
+Faker::Company.brazilian_company_number(formatted: true) #=> "00.000.000/0000-00"
 ```

--- a/doc/unreleased/default/id_number.md
+++ b/doc/unreleased/default/id_number.md
@@ -23,4 +23,7 @@ Faker::IDNumber.invalid_south_african_id_number #=> "1642972065088"
 
 # Generate a Brazilian citizen number (CPF)
 Faker::IDNumber.brazilian_citizen_number #=> "53540542221"
+
+# Generate a formatted Brazilian CPF
+Faker::IDNumber.brazilian_citizen_number(formatted: true) #=> 000.000.000-00
 ```

--- a/lib/faker/default/company.rb
+++ b/lib/faker/default/company.rb
@@ -153,7 +153,7 @@ module Faker
         regexify(/IT\d{2,4}\/\d{2,10}/)
       end
 
-      def brazilian_company_number
+      def brazilian_company_number(formatted: false)
         digits = Array.new(8) { Faker::Number.digit.to_i } + [0, 0, 0, Faker::Number.non_zero_digit.to_i]
 
         factors = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 6].cycle
@@ -163,7 +163,9 @@ module Faker
           digits << (checksum < 2 ? 0 : 11 - checksum)
         end
 
-        digits.join
+        number = digits.join
+
+        formatted ? format('%s.%s.%s/%s-%s', *number.scan(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/).flatten) : number
       end
 
       private

--- a/lib/faker/default/id_number.rb
+++ b/lib/faker/default/id_number.rb
@@ -75,11 +75,12 @@ module Faker
         [id_number, south_african_id_checksum_digit(id_number)].join
       end
 
-      def brazilian_citizen_number
+      def brazilian_citizen_number(formatted: false)
         digits = Faker::Number.leading_zero_number(9) until digits&.match(/(\d)((?!\1)\d)+/)
         first_digit = brazilian_citizen_number_checksum_digit(digits)
         second_digit = brazilian_citizen_number_checksum_digit(digits + first_digit)
-        [digits, first_digit, second_digit].join
+        number = [digits, first_digit, second_digit].join
+        formatted ? format('%s.%s.%s-%s', *number.scan(/\d{2,3}/).flatten) : number
       end
 
       private

--- a/test/faker/default/test_faker_company.rb
+++ b/test/faker/default/test_faker_company.rb
@@ -181,6 +181,11 @@ class TestFakerCompany < Test::Unit::TestCase
     assert_equal sample[13], second_digit
   end
 
+  def test_brazilian_company_number_formatted
+    sample = @tester.brazilian_company_number(formatted: true)
+    assert_match(/^\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}$/, sample)
+  end
+
   private
 
   def czech_o_n_checksum(org_no)

--- a/test/faker/default/test_faker_id_number.rb
+++ b/test/faker/default/test_faker_id_number.rb
@@ -81,6 +81,11 @@ class TestFakerIdNumber < Test::Unit::TestCase
     assert_equal sample[10], second_digit
   end
 
+  def test_brazilian_citizen_number_formatted
+    sample = @tester.brazilian_citizen_number(formatted: true)
+    assert_match(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/, sample)
+  end
+
   private
 
   def south_african_id_number_to_date_of_birth_string(sample)


### PR DESCRIPTION
Add support to valid and full random brazilian documents: CPF (person id) and CNPJ (company id).