### PR TITLE
Fix Faker::Internet.ip_v4_address to include all IP ranges

### DIFF
--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -102,8 +102,8 @@ module Faker
       end
 
       def ip_v4_address
-        ary = (2..254).to_a
-        [sample(ary), sample(ary), sample(ary), sample(ary)].join('.')
+        [rand_in_range(0, 255), rand_in_range(0, 255),
+         rand_in_range(0, 255), rand_in_range(0, 255)].join('.')
       end
 
       def private_ip_v4_address

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -147,10 +147,6 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_ip_v4_address
     assert_equal 3, @tester.ip_v4_address.count('.')
-
-    100.times do
-      assert @tester.ip_v4_address.split('.').map(&:to_i).max <= 255
-    end
   end
 
   def test_private_ip_v4_address

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -147,6 +147,11 @@ class TestFakerInternet < Test::Unit::TestCase
 
   def test_ip_v4_address
     assert_equal 3, @tester.ip_v4_address.count('.')
+
+    100.times do
+      assert @tester.ip_v4_address.split('.').map(&:to_i).min >= 0
+      assert @tester.ip_v4_address.split('.').map(&:to_i).max <= 255
+    end
   end
 
   def test_private_ip_v4_address


### PR DESCRIPTION
According to #1479 and [wikipedia](https://en.wikipedia.org/wiki/Dot-decimal_notation), the `Faker::Internet.ip_v4_address` does not generate all valid IP addresses.
This Pull Request closes #1479 by generating four octets, each one ranging from 0 to 255.