### PR TITLE
Deprecate Faker::Number.decimal_part and .leading_zero_number

### DIFF
--- a/lib/faker/default/number.rb
+++ b/lib/faker/default/number.rb
@@ -3,6 +3,8 @@
 module Faker
   class Number < Base
     class << self
+      extend Gem::Deprecate
+
       def number(digits = 10)
         num = ''
 
@@ -92,6 +94,9 @@ module Faker
           number * -1
         end
       end
+
+      deprecate :decimal_part, nil, 2019, 06
+      deprecate :leading_zero_number, nil, 2019, 06
     end
   end
 end


### PR DESCRIPTION
In version 2.0, `Faker::Number` methods are going to return `integer`, so we need to deprecate a few methods that won't make sense soon.

## Checklist
- [x] Deprecate `Faker::Number.decimal_part`
- [x] Deprecate `Faker::Number.leading_zero_number`

This PR is related to https://github.com/stympy/faker/pull/510.