### PR TITLE
Provide metadata for RubyGems

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*'] + %w[History.md License.txt CHANGELOG.md README.md]
   s.require_paths = ['lib']
 
-  s.metadata['changelog_uri'] = "https://github.com/stympy/faker/blob/master/CHANGELOG.md"
-  s.metadata['source_code_uri'] = "https://github.com/stympy/faker"
-  s.metadata['bug_tracker_uri'] = "https://github.com/stympy/faker/issues"
+  s.metadata['changelog_uri'] = 'https://github.com/stympy/faker/blob/master/CHANGELOG.md'
+  s.metadata['source_code_uri'] = 'https://github.com/stympy/faker'
+  s.metadata['bug_tracker_uri'] = 'https://github.com/stympy/faker/issues'
 end

--- a/faker.gemspec
+++ b/faker.gemspec
@@ -25,4 +25,8 @@ Gem::Specification.new do |s|
 
   s.files         = Dir['lib/**/*'] + %w[History.md License.txt CHANGELOG.md README.md]
   s.require_paths = ['lib']
+
+  s.metadata['changelog_uri'] = "https://github.com/stympy/faker/blob/master/CHANGELOG.md"
+  s.metadata['source_code_uri'] = "https://github.com/stympy/faker"
+  s.metadata['bug_tracker_uri'] = "https://github.com/stympy/faker/issues"
 end


### PR DESCRIPTION
This inserts the direct links to changelog/bugs in RubyGems. It also allows easier automatic processing of updates.