### PR TITLE
Adds the Faker::Sports::Basketball Generator

### DIFF
--- a/doc/sports/basketball.md
+++ b/doc/sports/basketball.md
@@ -1,0 +1,11 @@
+# Faker::Sports::Basketball
+
+```ruby
+Faker::Sports::Basketball.team #=> "Golden State Warriors"
+
+Faker::Sports::Basketball.player #=> "LeBron James"
+
+Faker::Sports::Basketball.coach #=> "Gregg Popovich"
+
+Faker::Sports::Basketball.position #=> "Point Guard"
+```

--- a/lib/faker/sports/basketball.rb
+++ b/lib/faker/sports/basketball.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Faker
+  module Sports
+    class Basketball < Base
+      class << self
+        def team
+          fetch('basketball.teams')
+        end
+
+        def player
+          fetch('basketball.players')
+        end
+
+        def coach
+          fetch('basketball.coaches')
+        end
+
+        def position
+          fetch('basketball.positions')
+        end
+      end
+    end
+  end
+end

--- a/lib/locales/en/basketball.yml
+++ b/lib/locales/en/basketball.yml
@@ -1,0 +1,99 @@
+en:
+  faker:
+    basketball:
+      teams:
+        - Atlanta Hawks
+        - Boston Celtics
+        - Brooklyn Nets
+        - Charlotte Hornets
+        - Chicago Bulls
+        - Cleveland Cavaliers
+        - Dallas Mavericks
+        - Denver Nuggets
+        - Detroit Pistons
+        - Golden State Warriors
+        - Houston Rockets
+        - Indiana Pacers
+        - Los Angeles Clippers
+        - Los Angeles Lakers
+        - Memphis Grizzlies
+        - Miami Heat
+        - Milwaukee Bucks
+        - Minnesota Timberwolves
+        - New Orleans Pelicans
+        - New York Knicks
+        - Oklahoma City Thunder
+        - Orlando Magic
+        - Philadelphia 76ers
+        - Phoenix Suns
+        - Portland Trail Blazers
+        - Sacramento Kings
+        - San Antonio Spurs
+        - Toronto Raptors
+        - Utah Jazz
+        - Washington Wizards
+      players:
+        - Kemba Walker
+        - Kyrie Irving
+        - Kawhi Leonard
+        - Giannis Antetokounmpo
+        - Joel Embiid
+        - Kyle Lowry
+        - Victor Oladipo
+        - Khris Middleton
+        - Bradley Beal
+        - Ben Simmons
+        - Blake Griffin
+        - Nikola Vučević
+        - Dwayne Wade
+        - D'Angelo Russell
+        - Stephen Curry
+        - James Harden
+        - Kevin Durant
+        - Paul George
+        - LeBron James
+        - Russell Westbrook
+        - Damian Lillard
+        - Klay Thompson
+        - Anthony Davis
+        - LaMarcus Aldridge
+        - Nikola Jokić
+        - Karl-Anthony Towns
+        - Dirk Nowitzki
+      coaches:
+        - Kenny Atkinson
+        - J.B. Bickerstaff
+        - James Borrego
+        - Jim Boylen
+        - Scott Brooks
+        - Brett Brown
+        - Mike Budenholzer
+        - Rick Carlisle
+        - Dwane Casey
+        - Steve Clifford
+        - Mike D'Antoni
+        - Billy Donovan
+        - Larry Drew
+        - David Fizdale
+        - Alvin Gentry
+        - Dave Joerger
+        - Steve Kerr
+        - Igor Kokoškov
+        - Michael Malone
+        - Nate McMillan
+        - Nick Nurse
+        - Lloyd Pierce
+        - Gregg Popovich
+        - Doc Rivers
+        - Ryan Saunders
+        - Quin Snyder
+        - Erik Spoelstra
+        - Brad Stevens
+        - Terry Stotts
+        - Luke Walton
+      positions:
+        - Point Guard
+        - Shooting Guard
+        - Small Forward
+        - Power Forward
+        - Center

--- a/test/faker/sports/test_faker_basketball.rb
+++ b/test/faker/sports/test_faker_basketball.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class TestFakerBasketball < Test::Unit::TestCase
+  def setup
+    @tester = Faker::Sports::Basketball
+  end
+
+  def test_team
+    assert @tester.team.match(/\w+/)
+  end
+
+  def test_player
+    assert @tester.player.match(/\w+/)
+  end
+
+  def test_coach
+    assert @tester.coach.match(/\w+/)
+  end
+
+  def test_position
+    assert @tester.position.match(/\w+/)
+  end
+end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -45,7 +45,7 @@ class TestDeterminism < Test::Unit::TestCase
 
   def subclasses
     Faker.constants.delete_if do |subclass|
-      %i[Base Bank Books Cat Char Base58 ChileRut Config Creature Date Dog DragonBall Dota ElderScrolls Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
+      %i[Base Bank Books Cat Char Base58 ChileRut Config Creature Date Dog DragonBall Dota ElderScrolls Fallout Games GamesHalfLife HeroesOfTheStorm Internet JapaneseMedia LeagueOfLegends Movies Myst Overwatch OnePiece Pokemon Sports SwordArtOnline TvShows Time VERSION Witcher WorldOfWarcraft Zelda].include?(subclass)
     end.sort
   end
 


### PR DESCRIPTION
Motivated by my discovery of the `Faker::Football` generator and the fact that my two favourite hobbies are basketball and programming, I decided to create a generator for basketball. Introducing the `Faker::Sports::Basketball` generator!

For now, I have added the following method to the generator (of course, this generator should be open for new methods or even new data added to its existing methods):

* `positions`: The 5 standard basketball positions
* `teams`: The names of the 30 teams in the NBA
* `players`: The names of some NBA players. Since this list in real life is _huge_, I decided to stick to just the participants of the 2019 NBA All Star Game
* `coaches`: The names of NBA coaches, current as of PR publication

**PR CAVEATS**

* I named my generator `Basketball`, but it's very possible that `NBA` is a more appropriate name. Although the NBA is the most recognizable league in the world, there are of course other popular leagues around the globe (NCAA, Euroleague, etc). It's possible that a generator named "Basketball" should also be including data from more leagues than just basketball
* I introduced a new module called `Sports` and nested the `Basketball` generator inside of it. If this is not welcome, I am okay with moving `Basketball` to the global `Faker` namespace. I thought this could be useful because I can see how new generators could naturally be grouped into `Sports`. But, if this move is accepted, then a future PR could move the `Football` and `WorldCup` generators into `Sports`
* I did not add any files into the `unreleased` directory. I was not sure if this was necessary. It was definitely not mentioned in the contributing guide.

Happy hooping!