### PR TITLE
Fix data of music albums

### DIFF
--- a/lib/locales/en/music.yml
+++ b/lib/locales/en/music.yml
@@ -26,7 +26,7 @@ en:
       "The Eminem Show", "Hybrid Theory", "Come Away with Me", "Unplugged", "True Blue", "Legend: The Best of Bob Marley & The Wailers", "Tapestry", "No Jacket Required", "Greatest Hits",
       "Bridge over Troubled Water", "The Joshua Tree", "...Baby One More Time", "Backstreet's Back", "Backstreet Boys", "Millennium", "Spice", "Happy Nation", "The Sign", "Whitney Houston",
       "(What's the Story) Morning Glory?", "The Marshall Mathers LP", "Like a Virgin", "Cross Road", "25", "Boston", "Oops!... I Did It Again", "The Colour of My Love", "Hysteria", "Faith",
-      "Dookie", "Can't Slow Down", "Daydream", "HIStory: Past", " Present and Future", " Book I", "Off the Wall", "The Woman in Me", "Breakfast in America", "Tracy Chapman",
+      "Dookie", "Can't Slow Down", "Daydream", "HIStory: Past, Present and Future, Book I", "Off the Wall", "The Woman in Me", "Breakfast in America", "Tracy Chapman",
       "Flashdance: Original Soundtrack from the Motion Picture", "Whitney", "Confessions", "X&Y", "High School Musical", "High School Musical 2", "Viva la Vida or Death and All His Friends",
       "I Dreamed a Dream", "Recovery", "Midnight Memories", "Frozen", "Lemonade", "Brand New Eyes", "All We Know Is Falling", "Riot!", "Songs About Jane", "Hands All Over"]
       genres: ["Rock", "Pop", "Electronic", "Folk", "World", "Country", "Jazz", "Funk", "Soul", "Hip Hop", "Classical", "Latin", "Reggae", "Stage And Screen", "Blues", "Non Music", "Rap"]


### PR DESCRIPTION
Fix data added by #1211.

There are no such albums as `"HIStory: Past"`, `" Present and Future"` and `" Book I"`.
But `"HIStory: Past, Present and Future, Book I"` exists:
https://en.wikipedia.org/wiki/HIStory:_Past,_Present_and_Future,_Book_I

Anyway, album names starting with a space are invalid.