### PR TITLE
Add fighters and DLC to Faker::Games::SuperSmashBros

### DIFF
--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -24,10 +24,13 @@ en:
           - Greninja
           - Ice Climbers
           - Ike
+          - Incineroar
           - Inkling
           - Isabelle
           - Ivysaur
           - Jigglypuff
+          - Joker
+          - Ken
           - King Dedede
           - King K. Rool
           - Kirby
@@ -53,6 +56,7 @@ en:
           - Peach
           - Pichu
           - Pikachu
+          - Piranha Plant
           - Pit
           - Pokémon Trainer
           - R.O.B.


### PR DESCRIPTION
This faker was made before the final characters had been announced.
Further updates will come when the rest of the Challenger Packs are
announced.