### PR TITLE
Add Faker::Internet.uuid

### DIFF
--- a/doc/unreleased/default/internet.md
+++ b/doc/unreleased/default/internet.md
@@ -79,4 +79,6 @@ Faker::Internet.slug('foo bar', '-') #=> "foo-bar"
 # Optional argument: vendor=nil
 Faker::Internet.user_agent #=> "Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7; AOLBuild 4343.19; Windows NT 6.1; WOW64; Trident/5.0; FunWebProducts)"
 Faker::Internet.user_agent(:firefox) #=> "Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0"
+
+Faker::Internet.uuid #=> "929ef6ef-b11f-38c9-111b-accd67a258b2"
 ```

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -193,7 +193,11 @@ module Faker
       end
 
       def uuid
-        Faker::Config.random.bytes(16).unpack('H8H4H4H4H12').join('-')
+        # borrowed from: https://github.com/ruby/ruby/blob/d48783bb0236db505fe1205d1d9822309de53a36/lib/securerandom.rb#L250
+        ary = Faker::Config.random.bytes(16).unpack('NnnnnN')
+        ary[2] = (ary[2] & 0x0fff) | 0x4000
+        ary[3] = (ary[3] & 0x3fff) | 0x8000
+        '%08x-%04x-%04x-%04x-%04x%08x' % ary # rubocop:disable Style/FormatString
       end
 
       alias user_name username

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -192,6 +192,10 @@ module Faker
         sample(agents)
       end
 
+      def uuid
+        Faker::Config.random.bytes(16).unpack('H8H4H4H4H12').join('-')
+      end
+
       alias user_name username
     end
   end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -282,6 +282,8 @@ class TestFakerInternet < Test::Unit::TestCase
   end
 
   def test_uuid
-    assert @tester.uuid.match(/\h{8}-\h{4}-\h{4}-\h{4}-\h{12}/)
+    uuid = @tester.uuid
+    assert_equal(36, uuid.size)
+    assert_match(/\A\h{8}-\h{4}-4\h{3}-\h{4}-\h{12}\z/, uuid)
   end
 end

--- a/test/faker/default/test_faker_internet.rb
+++ b/test/faker/default/test_faker_internet.rb
@@ -280,4 +280,8 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.user_agent(nil).match(/Mozilla|Opera/)
     assert @tester.user_agent(1).match(/Mozilla|Opera/)
   end
+
+  def test_uuid
+    assert @tester.uuid.match(/\h{8}-\h{4}-\h{4}-\h{4}-\h{12}/)
+  end
 end


### PR DESCRIPTION
UUIDs are incredibly common. Many databases, APIs, etc will use them to identify resources. Being able to generate these easily is paramount to having a productive development environment.

### So, why not just use `SecureRandom.uuid`?

The beauty of faker is that is can be used to generate *deterministic* sequences of numbers in a non-deterministic world. This makes debugging much easier, as we have one less thing to reason about.

This patch uses fakers PRNG to build a UUID, which solves this problem.

supersedes https://github.com/stympy/faker/pull/943