### PR TITLE
fix shallow_json for frozen_string_literal

### DIFF
--- a/lib/faker/default/json.rb
+++ b/lib/faker/default/json.rb
@@ -4,16 +4,16 @@ module Faker
 
     class << self
       def shallow_json(width = 3, options = { key: 'Name.first_name', value: 'Name.first_name' })
-        options[:key] = options[:key].prepend('Faker::')
-        options[:value] = options[:value].prepend('Faker::')
+        options[:key] = 'Faker::' + options[:key]
+        options[:value] = 'Faker::' + options[:value]
 
         hash = build_shallow_hash(width, options)
         JSON.generate(hash)
       end
 
       def add_depth_to_json(json = shallow_json, width = 3, options = { key: 'Name.first_name', value: 'Name.first_name' })
-        options[:key] = options[:key].prepend('Faker::')
-        options[:value] = options[:value].prepend('Faker::')
+        options[:key] = 'Faker::' + options[:key]
+        options[:value] = 'Faker::' + options[:value]
 
         hash = JSON.parse(json)
         hash.each do |key, _|


### PR DESCRIPTION
Fixes #1598. Don't think I need to write tests for this because it's basically replacing `prepend`.