### PR TITLE
Stargate documentation incorrect name fix

### DIFF
--- a/doc/tv_shows/stargate.md
+++ b/doc/tv_shows/stargate.md
@@ -1,9 +1,9 @@
 # Faker::TvShows::Stargate
 
 ```ruby
-Faker::TvShows::StarTrek.character #=> "Jack O'Neill"
+Faker::TvShows::Stargate.character #=> "Jack O'Neill"
 
-Faker::TvShows::StarTrek.planet #=> "Abydos"
+Faker::TvShows::Stargate.planet #=> "Abydos"
 
-Faker::TvShows::StarTrek.quote #=> "General, request permission to beat the crap out of this man."
+Faker::TvShows::Stargate.quote #=> "General, request permission to beat the crap out of this man."
 ```


### PR DESCRIPTION
`Stargate` in documentation was accidentally `StarTrek` and I've changed it to be correct.

Fixes https://github.com/stympy/faker/issues/1609