### PR TITLE
CHANGELOG: Manually edit the tag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@
 
 ------------------------------------------------------------------------------
 
-## [v1.9.6](https://github.com/stympy/faker/tree/v1.9.5) (2019-07-05)
+## [v1.9.6](https://github.com/stympy/faker/tree/1.9.5) (2019-07-05)
 
 Fix lib/faker/version.rb
 
-## [v1.9.5](https://github.com/stympy/faker/tree/v1.9.5) (2019-07-04)
+## [v1.9.5](https://github.com/stympy/faker/tree/v.1.9.5) (2019-07-04)
 
 ### Bug
 
@@ -39,7 +39,7 @@ Fix lib/faker/version.rb
 
 ------------------------------------------------------------------------------
 
-## [v1.9.4](https://github.com/stympy/faker/tree/v1.9.4) (2019-06-19)
+## [v1.9.4](https://github.com/stympy/faker/tree/1.9.4) (2019-06-19)
 
 ### Bug/Fixes
 
@@ -111,7 +111,7 @@ Fix lib/faker/version.rb
 
 ------------------------------------------------------------------------------
 
-## [v1.9.3](https://github.com/stympy/faker/tree/v1.9.2) (2019-02-12)
+## [v1.9.3](https://github.com/stympy/faker/tree/v1.9.3) (2019-02-12)
 
 [Full Changelog](https://github.com/stympy/faker/compare/v1.9.2...v1.9.3)
 


### PR DESCRIPTION
Issue# 
------

`No-Story`

Description:
------

To keep the CHANGELOG release links unbroken, this PR uses the **existing tags** in the links.


Question for reviewer
-----

If the tool github-changelog-generator is no longer in use, this is an easy edit.

If the tool is still in use, it _might_ be worth it to add those Git tags, to keep those links functioning.