### PR TITLE
Update Faker::Games::SuperSmashBros entries

### DIFF
--- a/lib/locales/en/super_smash_bros.yml
+++ b/lib/locales/en/super_smash_bros.yml
@@ -3,6 +3,7 @@ en:
     games:
       super_smash_bros:
         fighter:
+          - Banjo-Kazooie
           - Bayonetta
           - Bowser
           - Bowser Jr.
@@ -22,6 +23,7 @@ en:
           - Fox
           - Ganondorf
           - Greninja
+          - Hero
           - Ice Climbers
           - Ike
           - Incineroar
@@ -137,6 +139,7 @@ en:
           - Mario Bros.
           - Mario Circuit
           - Mario Galaxy
+          - Mementos
           - Midgar
           - Miiverse
           - Moray Towers
@@ -178,6 +181,7 @@ en:
           - Skyworld
           - Smashville
           - Spear Pillar
+          - Spiral Mountain
           - Spirit Train
           - Summit
           - Super Happy Tree


### PR DESCRIPTION
Description:
------
This PR updates the `Faker::Games::SuperSmashBros` faker to support the new DLC characters and stages being released this year.

As yet, the name of the Hero's stage is unknown. I didn't include Joker's stage, Mementos, in my last PR.