### PR TITLE
Fix off-by-one error when formatting month names

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -19,6 +19,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
+    - 
     - Jan
     - Feb
     - Mar
@@ -44,6 +45,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
+    - 
     - January
     - February
     - March


### PR DESCRIPTION
Closes #1674

More info in the ticket, but tl;dr is that localized month names were off by one.